### PR TITLE
feat(cli): add install-skill command

### DIFF
--- a/packages/cli/bin.ts
+++ b/packages/cli/bin.ts
@@ -36,6 +36,38 @@ yargs(hideBin(process.argv))
     const { runLogout } = await import('./src/commands/logout.js');
     await runLogout();
   })
+  .command(
+    'install-skill',
+    'Install bundled AuthKit skills to coding agents',
+    (yargs) => {
+      return yargs
+        .option('list', {
+          alias: 'l',
+          type: 'boolean',
+          description: 'List available skills without installing',
+        })
+        .option('skill', {
+          alias: 's',
+          type: 'array',
+          string: true,
+          description: 'Install specific skill(s)',
+        })
+        .option('agent', {
+          alias: 'a',
+          type: 'array',
+          string: true,
+          description: 'Target specific agent(s): claude-code, codex, cursor, goose',
+        });
+    },
+    async (argv) => {
+      const { runInstallSkill } = await import('./src/commands/install-skill.js');
+      await runInstallSkill({
+        list: argv.list as boolean | undefined,
+        skill: argv.skill as string[] | undefined,
+        agent: argv.agent as string[] | undefined,
+      });
+    },
+  )
   .options({
     debug: {
       default: false,

--- a/packages/cli/src/commands/install-skill.spec.ts
+++ b/packages/cli/src/commands/install-skill.spec.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import {
+  createAgents,
+  discoverSkills,
+  detectAgents,
+  installSkill,
+  type AgentConfig,
+} from './install-skill.js';
+
+describe('install-skill', () => {
+  let testDir: string;
+  let skillsDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'install-skill-test-'));
+    skillsDir = join(testDir, 'skills');
+    homeDir = join(testDir, 'home');
+
+    mkdirSync(skillsDir);
+    mkdirSync(homeDir);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('createAgents', () => {
+    it('creates agent configs with correct paths', () => {
+      const agents = createAgents(homeDir);
+
+      expect(agents['claude-code'].globalSkillsDir).toBe(join(homeDir, '.claude/skills'));
+      expect(agents['codex'].globalSkillsDir).toBe(join(homeDir, '.codex/skills'));
+      expect(agents['cursor'].globalSkillsDir).toBe(join(homeDir, '.cursor/skills'));
+      expect(agents['goose'].globalSkillsDir).toBe(join(homeDir, '.config/goose/skills'));
+    });
+
+    it('detect returns true when agent directory exists', () => {
+      mkdirSync(join(homeDir, '.claude'));
+      const agents = createAgents(homeDir);
+
+      expect(agents['claude-code'].detect()).toBe(true);
+      expect(agents['codex'].detect()).toBe(false);
+    });
+
+    it('detect returns false when agent directory does not exist', () => {
+      const agents = createAgents(homeDir);
+
+      expect(agents['claude-code'].detect()).toBe(false);
+      expect(agents['codex'].detect()).toBe(false);
+    });
+  });
+
+  describe('discoverSkills', () => {
+    it('returns empty array when no skills exist', async () => {
+      const skills = await discoverSkills(skillsDir);
+      expect(skills).toEqual([]);
+    });
+
+    it('finds skills with SKILL.md files', async () => {
+      mkdirSync(join(skillsDir, 'skill-one'));
+      writeFileSync(join(skillsDir, 'skill-one', 'SKILL.md'), '# Skill One');
+
+      mkdirSync(join(skillsDir, 'skill-two'));
+      writeFileSync(join(skillsDir, 'skill-two', 'SKILL.md'), '# Skill Two');
+
+      const skills = await discoverSkills(skillsDir);
+
+      expect(skills).toContain('skill-one');
+      expect(skills).toContain('skill-two');
+      expect(skills).toHaveLength(2);
+    });
+
+    it('ignores directories without SKILL.md', async () => {
+      mkdirSync(join(skillsDir, 'has-skill'));
+      writeFileSync(join(skillsDir, 'has-skill', 'SKILL.md'), '# Skill');
+
+      mkdirSync(join(skillsDir, 'no-skill'));
+      writeFileSync(join(skillsDir, 'no-skill', 'README.md'), '# Not a skill');
+
+      const skills = await discoverSkills(skillsDir);
+
+      expect(skills).toContain('has-skill');
+      expect(skills).not.toContain('no-skill');
+      expect(skills).toHaveLength(1);
+    });
+
+    it('ignores files (not directories)', async () => {
+      writeFileSync(join(skillsDir, 'not-a-dir.md'), '# File');
+
+      mkdirSync(join(skillsDir, 'real-skill'));
+      writeFileSync(join(skillsDir, 'real-skill', 'SKILL.md'), '# Skill');
+
+      const skills = await discoverSkills(skillsDir);
+
+      expect(skills).toEqual(['real-skill']);
+    });
+  });
+
+  describe('detectAgents', () => {
+    it('returns empty array when no agents detected', () => {
+      const agents = createAgents(homeDir);
+      const detected = detectAgents(agents);
+
+      expect(detected).toEqual([]);
+    });
+
+    it('returns detected agents', () => {
+      mkdirSync(join(homeDir, '.claude'));
+      mkdirSync(join(homeDir, '.cursor'));
+
+      const agents = createAgents(homeDir);
+      const detected = detectAgents(agents);
+
+      expect(detected).toHaveLength(2);
+      expect(detected.map((a) => a.name)).toContain('claude-code');
+      expect(detected.map((a) => a.name)).toContain('cursor');
+    });
+
+    it('filters by provided agent names', () => {
+      mkdirSync(join(homeDir, '.claude'));
+      mkdirSync(join(homeDir, '.cursor'));
+      mkdirSync(join(homeDir, '.codex'));
+
+      const agents = createAgents(homeDir);
+      const detected = detectAgents(agents, ['claude-code', 'codex']);
+
+      expect(detected).toHaveLength(2);
+      expect(detected.map((a) => a.name)).toContain('claude-code');
+      expect(detected.map((a) => a.name)).toContain('codex');
+      expect(detected.map((a) => a.name)).not.toContain('cursor');
+    });
+
+    it('only returns agents that are both filtered and detected', () => {
+      mkdirSync(join(homeDir, '.claude'));
+
+      const agents = createAgents(homeDir);
+      const detected = detectAgents(agents, ['claude-code', 'codex']);
+
+      expect(detected).toHaveLength(1);
+      expect(detected[0].name).toBe('claude-code');
+    });
+  });
+
+  describe('installSkill', () => {
+    let targetAgent: AgentConfig;
+
+    beforeEach(() => {
+      mkdirSync(join(skillsDir, 'test-skill'));
+      writeFileSync(
+        join(skillsDir, 'test-skill', 'SKILL.md'),
+        '---\nname: test-skill\n---\n# Test Skill',
+      );
+
+      targetAgent = {
+        name: 'test-agent',
+        displayName: 'Test Agent',
+        globalSkillsDir: join(homeDir, '.test-agent/skills'),
+        detect: () => true,
+      };
+    });
+
+    it('copies SKILL.md to target directory', async () => {
+      const result = await installSkill(skillsDir, 'test-skill', targetAgent);
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+
+      const targetFile = join(homeDir, '.test-agent/skills/test-skill/SKILL.md');
+      expect(existsSync(targetFile)).toBe(true);
+
+      const content = readFileSync(targetFile, 'utf-8');
+      expect(content).toContain('# Test Skill');
+    });
+
+    it('creates nested directories as needed', async () => {
+      const result = await installSkill(skillsDir, 'test-skill', targetAgent);
+
+      expect(result.success).toBe(true);
+      expect(existsSync(join(homeDir, '.test-agent/skills/test-skill'))).toBe(true);
+    });
+
+    it('returns error when source skill does not exist', async () => {
+      const result = await installSkill(skillsDir, 'nonexistent-skill', targetAgent);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('overwrites existing skill file', async () => {
+      await installSkill(skillsDir, 'test-skill', targetAgent);
+
+      writeFileSync(
+        join(skillsDir, 'test-skill', 'SKILL.md'),
+        '---\nname: test-skill\n---\n# Updated Skill',
+      );
+
+      const result = await installSkill(skillsDir, 'test-skill', targetAgent);
+
+      expect(result.success).toBe(true);
+
+      const content = readFileSync(
+        join(homeDir, '.test-agent/skills/test-skill/SKILL.md'),
+        'utf-8',
+      );
+      expect(content).toContain('# Updated Skill');
+    });
+  });
+});

--- a/packages/cli/src/commands/install-skill.ts
+++ b/packages/cli/src/commands/install-skill.ts
@@ -1,0 +1,167 @@
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import { existsSync } from 'fs';
+import { mkdir, copyFile, readdir } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+
+export interface AgentConfig {
+  name: string;
+  displayName: string;
+  globalSkillsDir: string;
+  detect: () => boolean;
+}
+
+export function createAgents(home: string): Record<string, AgentConfig> {
+  return {
+    'claude-code': {
+      name: 'claude-code',
+      displayName: 'Claude Code',
+      globalSkillsDir: join(home, '.claude/skills'),
+      detect: () => existsSync(join(home, '.claude')),
+    },
+    codex: {
+      name: 'codex',
+      displayName: 'Codex',
+      globalSkillsDir: join(home, '.codex/skills'),
+      detect: () => existsSync(join(home, '.codex')),
+    },
+    cursor: {
+      name: 'cursor',
+      displayName: 'Cursor',
+      globalSkillsDir: join(home, '.cursor/skills'),
+      detect: () => existsSync(join(home, '.cursor')),
+    },
+    goose: {
+      name: 'goose',
+      displayName: 'Goose',
+      globalSkillsDir: join(home, '.config/goose/skills'),
+      detect: () => existsSync(join(home, '.config/goose')),
+    },
+  };
+}
+
+export interface InstallSkillOptions {
+  list?: boolean;
+  skill?: string[];
+  agent?: string[];
+}
+
+export function getSkillsDir(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  // From dist/src/commands/install-skill.js -> skills/
+  return join(dirname(currentFile), '..', '..', '..', 'skills');
+}
+
+export async function discoverSkills(skillsDir: string): Promise<string[]> {
+  const entries = await readdir(skillsDir, { withFileTypes: true });
+
+  return entries
+    .filter((e) => e.isDirectory() && existsSync(join(skillsDir, e.name, 'SKILL.md')))
+    .map((e) => e.name);
+}
+
+export function detectAgents(
+  agents: Record<string, AgentConfig>,
+  filter?: string[],
+): AgentConfig[] {
+  const detected: AgentConfig[] = [];
+
+  for (const [key, config] of Object.entries(agents)) {
+    if (filter && !filter.includes(key)) continue;
+    if (config.detect()) {
+      detected.push(config);
+    }
+  }
+
+  return detected;
+}
+
+export async function installSkill(
+  skillsDir: string,
+  skillName: string,
+  agent: AgentConfig,
+): Promise<{ success: boolean; error?: string }> {
+  const sourceFile = join(skillsDir, skillName, 'SKILL.md');
+  const targetDir = join(agent.globalSkillsDir, skillName);
+  const targetFile = join(targetDir, 'SKILL.md');
+
+  try {
+    await mkdir(targetDir, { recursive: true });
+    await copyFile(sourceFile, targetFile);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
+export async function runInstallSkill(options: InstallSkillOptions): Promise<void> {
+  const home = homedir();
+  const agents = createAgents(home);
+  const skillsDir = getSkillsDir();
+  const skills = await discoverSkills(skillsDir);
+
+  if (options.list) {
+    console.log(chalk.bold('\nAvailable Skills:\n'));
+    for (const skill of skills) {
+      console.log(`  ${chalk.cyan(skill)}`);
+    }
+    console.log();
+    return;
+  }
+
+  const targetSkills = options.skill ? skills.filter((s) => options.skill!.includes(s)) : skills;
+
+  if (targetSkills.length === 0) {
+    console.error(chalk.red('No matching skills found.'));
+    console.log('Available skills:', skills.join(', '));
+    process.exit(1);
+  }
+
+  const targetAgents = detectAgents(agents, options.agent);
+
+  if (targetAgents.length === 0) {
+    if (options.agent) {
+      console.error(chalk.red('Specified agents not found.'));
+    } else {
+      console.error(chalk.red('No coding agents detected.'));
+    }
+    console.log('Supported agents:', Object.keys(agents).join(', '));
+    process.exit(1);
+  }
+
+  console.log(chalk.bold('\nInstalling skills...\n'));
+
+  const results: Array<{ skill: string; agent: string; success: boolean; error?: string }> = [];
+
+  for (const skill of targetSkills) {
+    for (const agent of targetAgents) {
+      const result = await installSkill(skillsDir, skill, agent);
+      results.push({
+        skill,
+        agent: agent.displayName,
+        ...result,
+      });
+    }
+  }
+
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  if (successful.length > 0) {
+    console.log(chalk.green(`✓ Installed ${successful.length} skill(s):\n`));
+    for (const r of successful) {
+      console.log(`  ${chalk.cyan(r.skill)} → ${chalk.dim(r.agent)}`);
+    }
+  }
+
+  if (failed.length > 0) {
+    console.log(chalk.red(`\n✗ Failed to install ${failed.length}:\n`));
+    for (const r of failed) {
+      console.log(`  ${r.skill} → ${r.agent}: ${chalk.dim(r.error)}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(chalk.green('\nDone!'));
+}


### PR DESCRIPTION
## Summary

Add command to install bundled AuthKit skills to coding agents (Claude Code, Codex, Cursor, Goose). Installs all skills to all detected agents by default.

## Usage

```bash
wizard install-skill          # install all to detected agents
wizard install-skill --list   # list available skills
wizard install-skill -s name  # install specific skill
wizard install-skill -a agent # target specific agent
```