### PR TITLE
feat(llm-gateway): add OTel metrics for token usage tracking

### DIFF
--- a/packages/llm-gateway/src/telemetry/metrics.ts
+++ b/packages/llm-gateway/src/telemetry/metrics.ts
@@ -24,3 +24,16 @@ export const durationHistogram = meter.createHistogram('wizard.duration', {
   description: 'Session duration',
   unit: 'ms',
 });
+
+// Gateway metrics for abuse detection
+export const gatewayRequests = meter.createCounter('gateway.requests', {
+  description: 'API requests through gateway',
+});
+
+export const gatewayTokensIn = meter.createCounter('gateway.tokens.input', {
+  description: 'Input tokens consumed',
+});
+
+export const gatewayTokensOut = meter.createCounter('gateway.tokens.output', {
+  description: 'Output tokens generated',
+});


### PR DESCRIPTION
## Summary

- Adds OpenTelemetry metrics to track per-user token consumption for abuse detection
- Three new counters: `gateway.requests`, `gateway.tokens.input`, `gateway.tokens.output`
- All metrics tagged with `user` (from JWT sub claim) and `model` for Datadog querying
- Works for both streaming and non-streaming responses