### PR TITLE
feat: improve debug logging with session-based log files

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -151,10 +151,15 @@ yargs(hideBin(process.argv))
       void import('./src/run.js').then(({ runWizard }) =>
         runWizard(options as unknown as WizardOptions)
           .then(() => process.exit(0))
-          .catch((err) => {
+          .catch(async (err) => {
+            const { getLogFilePath } = await import('./src/utils/debug.js');
+            const logPath = getLogFilePath();
             if (argv.debug) {
               console.error('\nWizard failed with error:');
               console.error(err instanceof Error ? err.stack || err.message : String(err));
+            }
+            if (logPath) {
+              console.error(`\nSee debug logs at: ${logPath}`);
             }
             process.exit(1);
           }),
@@ -203,10 +208,15 @@ yargs(hideBin(process.argv))
 
       void runWizard(options as unknown as WizardOptions)
         .then(() => process.exit(0))
-        .catch((err) => {
+        .catch(async (err) => {
+          const { getLogFilePath } = await import('./src/utils/debug.js');
+          const logPath = getLogFilePath();
           if (options.debug) {
             console.error('\nWizard failed with error:');
             console.error(err instanceof Error ? err.stack || err.message : String(err));
+          }
+          if (logPath) {
+            console.error(`\nSee debug logs at: ${logPath}`);
           }
           process.exit(1);
         });

--- a/installer.config.ts
+++ b/installer.config.ts
@@ -18,7 +18,6 @@ export const config = {
   nodeVersion: '>=20.20',
 
   logging: {
-    logFile: '/tmp/authkit-wizard.log',
     debugMode: false,
   },
 

--- a/src/lib/run-with-core.ts
+++ b/src/lib/run-with-core.ts
@@ -12,7 +12,7 @@ import type { WizardOptions } from '../utils/types.js';
 import type { WizardMachineContext, DetectionOutput, GitCheckOutput, AgentOutput } from './wizard-core.types.js';
 import { Integration } from './constants.js';
 import { parseEnvFile } from '../utils/env-parser.js';
-import { enableDebugLogs, initLogFile, logToFile } from '../utils/debug.js';
+import { enableDebugLogs, initLogFile, logInfo, logError } from '../utils/debug.js';
 
 import { getAccessToken, getCredentials } from './credentials.js';
 import { analytics } from '../utils/analytics.js';
@@ -85,7 +85,7 @@ export async function runWithCore(options: WizardOptions): Promise<void> {
   if (options.debug) {
     enableDebugLogs();
   }
-  logToFile('Wizard starting with options:', {
+  logInfo('Wizard starting with options:', {
     debug: options.debug,
     dashboard: options.dashboard,
     local: options.local,
@@ -293,7 +293,7 @@ export async function runWithCore(options: WizardOptions): Promise<void> {
     });
   } catch (error) {
     wizardStatus = 'error';
-    logToFile('Wizard failed with error:', error instanceof Error ? error.stack || error.message : String(error));
+    logError('Wizard failed with error:', error instanceof Error ? error.stack || error.message : String(error));
     throw error;
   } finally {
     process.off('SIGINT', handleSigint);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -21,7 +21,6 @@ export interface InstallerConfig {
   };
   nodeVersion: string;
   logging: {
-    logFile: string;
     debugMode: boolean;
   };
   documentation: {

--- a/src/lib/token-refresh.spec.ts
+++ b/src/lib/token-refresh.spec.ts
@@ -25,7 +25,7 @@ vi.mock('node:os', async (importOriginal) => {
 // Mock debug utilities
 vi.mock('../utils/debug.js', () => ({
   debug: vi.fn(),
-  logToFile: vi.fn(),
+  logInfo: vi.fn(),
 }));
 
 // Import after mocks are set up

--- a/src/lib/token-refresh.ts
+++ b/src/lib/token-refresh.ts
@@ -1,5 +1,5 @@
 import { getCredentials, isTokenExpired, Credentials } from './credentials.js';
-import { logToFile } from '../utils/debug.js';
+import { logInfo } from '../utils/debug.js';
 
 export interface TokenValidationResult {
   success: boolean;
@@ -16,21 +16,21 @@ export async function ensureValidToken(): Promise<TokenValidationResult> {
   const creds = getCredentials();
 
   if (!creds) {
-    logToFile('[ensureValidToken] No credentials found');
+    logInfo('[ensureValidToken] No credentials found');
     return { success: false, error: 'Not authenticated' };
   }
 
-  logToFile(`[ensureValidToken] Token expiresAt: ${new Date(creds.expiresAt).toISOString()}`);
-  logToFile(`[ensureValidToken] Current time: ${new Date().toISOString()}`);
+  logInfo(`[ensureValidToken] Token expiresAt: ${new Date(creds.expiresAt).toISOString()}`);
+  logInfo(`[ensureValidToken] Current time: ${new Date().toISOString()}`);
 
   if (isTokenExpired(creds)) {
-    logToFile('[ensureValidToken] Token expired, re-authentication required');
+    logInfo('[ensureValidToken] Token expired, re-authentication required');
     return {
       success: false,
       error: 'Session expired. Run `wizard login` to re-authenticate.',
     };
   }
 
-  logToFile('[ensureValidToken] Token valid');
+  logInfo('[ensureValidToken] Token valid');
   return { success: true, credentials: creds };
 }

--- a/src/utils/debug.spec.ts
+++ b/src/utils/debug.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Create test directory before mocking
+const testDir = mkdtempSync(join(tmpdir(), 'wizard-test-'));
+
+// Mock homedir to use temp directory
+vi.mock('os', async () => {
+  const actual = await vi.importActual('os');
+  return { ...actual, homedir: () => testDir };
+});
+
+// Mock clack to avoid side effects
+vi.mock('./clack.js', () => ({
+  default: {
+    log: { info: vi.fn() },
+  },
+}));
+
+describe('debug logging', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  // Clean up after all tests
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup failures
+    }
+  });
+
+  it('creates log file on init', async () => {
+    const { initLogFile, getLogFilePath } = await import('./debug.js');
+
+    initLogFile();
+    const path = getLogFilePath();
+
+    expect(path).toBeTruthy();
+    expect(path).toContain('.workos-installer/logs/wizard-');
+  });
+
+  it('rotates old log files keeping max 10', async () => {
+    // Create the logs directory
+    const logsDir = join(testDir, '.workos-installer', 'logs');
+    mkdirSync(logsDir, { recursive: true });
+
+    // Create 12 fake log files with timestamps that sort correctly
+    for (let i = 0; i < 12; i++) {
+      const day = i.toString().padStart(2, '0');
+      writeFileSync(join(logsDir, `wizard-2024-01-${day}T00-00-00.000Z.log`), '');
+    }
+
+    // Import fresh module
+    vi.resetModules();
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual('os');
+      return { ...actual, homedir: () => testDir };
+    });
+    vi.doMock('./clack.js', () => ({
+      default: { log: { info: vi.fn() } },
+    }));
+
+    const { initLogFile } = await import('./debug.js');
+    initLogFile();
+
+    const files = readdirSync(logsDir).filter((f) => f.startsWith('wizard-') && f.endsWith('.log'));
+    expect(files.length).toBe(10);
+  });
+
+  it('writes severity prefixes', async () => {
+    const { initLogFile, getLogFilePath, logInfo, logWarn, logError } = await import('./debug.js');
+
+    initLogFile();
+    logInfo('test info');
+    logWarn('test warn');
+    logError('test error');
+
+    const logPath = getLogFilePath();
+    expect(logPath).toBeTruthy();
+
+    const content = readFileSync(logPath!, 'utf-8');
+    expect(content).toContain('ℹ️  INFO: test info');
+    expect(content).toContain('⚠️  WARN: test warn');
+    expect(content).toContain('❌ ERROR: test error');
+  });
+
+  it('getLogFilePath returns null before init', async () => {
+    vi.resetModules();
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual('os');
+      return { ...actual, homedir: () => testDir };
+    });
+    vi.doMock('./clack.js', () => ({
+      default: { log: { info: vi.fn() } },
+    }));
+
+    const { getLogFilePath } = await import('./debug.js');
+    expect(getLogFilePath()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Move logs from `/tmp` to `~/.workos-installer/logs/` with timestamped session files
- Add severity-level logging (`logInfo`, `logWarn`, `logError`) with proper usage
- Implement log rotation (keeps 10 most recent files)
- Display log path on wizard failure for easier debugging

## Why
Previous logging wrote to a single `/tmp/authkit-wizard.log` file that could be clobbered between runs and wasn't easily discoverable. Users debugging issues had no clear path to find logs.

## Notes
- Removed deprecated `logToFile` and `LOG_FILE_PATH` exports (pre-release, no backward compat needed)
- Removed noisy "SDK Message type" debug console output
- Bash command denials now log as WARN, agent errors as ERROR