### PR TITLE
fix: use v0.x.x tag format instead of workos-v0.x.x

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Configure release-please to use simpler `v0.x.x` tag format instead of `workos-v0.x.x`

## Test plan
- [ ] Verify next release-please run creates tags in correct format