### PR TITLE
fix: trigger npm publish when release-please creates a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
@@ -20,3 +21,8 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml


### PR DESCRIPTION
## Summary
- Events triggered by `GITHUB_TOKEN` don't create new workflow runs (GitHub's infinite loop prevention)
- This meant `release: [published]` never fired when release-please created a release
- Now release-please directly calls the publish workflow via `workflow_call`

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger release workflow for v0.3.0: `gh workflow run release.yml --repo workos/cli`
- [ ] Verify next release auto-publishes to npm