### PR TITLE
fix: add repository URL for npm provenance publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
       id-token: write

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.1",
   "type": "module",
   "description": "The Official Workos CLI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/workos/cli"
+  },
   "keywords": [
     "workos",
     "authkit",


### PR DESCRIPTION
## Summary
- Add `repository` field to package.json (required for npm provenance verification)
- Add `npm` environment to release workflow for clearer OIDC subject

## Context
npm provenance publishing requires `package.json` repository URL to match the GitHub repo in the OIDC token.

## Test plan
- [ ] Merge and verify npm publish succeeds