### PR TITLE
fix: installer skill loop and Node deprecation warning

### DIFF
--- a/skills/workos-authkit-nextjs/SKILL.md
+++ b/skills/workos-authkit-nextjs/SKILL.md
@@ -148,7 +148,7 @@ This is required for:
 
 ```tsx
 // app/layout.tsx
-import { AuthKitProvider } from '@workos-inc/authkit-nextjs';
+import { AuthKitProvider } from '@workos-inc/authkit-nextjs/components';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -161,13 +161,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-Check README for exact import path - it may be a subpath export like `@workos-inc/authkit-nextjs/components`.
-
 **Do NOT skip this step** even if using server-side auth patterns elsewhere.
 
 ## Step 8: UI Integration
 
-Add auth UI to `app/page.tsx` using SDK functions. See README for `getUser`, `getSignInUrl`, `signOut` usage.
+Add auth UI to `app/page.tsx` using SDK functions. See README for auth helper usage (`withAuth`/`getUser`, `getSignInUrl`, `signOut`).
+
+**Note:** The SDK renamed `getUser` to `withAuth` in newer versions. Use whichever function the installed SDK version exports — do NOT rename existing working imports.
 
 ## Verification Checklist (ALL MUST PASS)
 
@@ -238,7 +238,7 @@ This error causes OAuth codes to expire ("invalid_grant"), so fix the handler fi
 
 ### Build fails after AuthKitProvider
 
-- Check: README for correct import path (may be subpath export)
+- Check: Import path matches what README specifies (root export vs `/components` subpath)
 - Check: No client/server boundary violations
 
 ### NEXT*PUBLIC* prefix issues

--- a/src/lib/validation/build-validator.ts
+++ b/src/lib/validation/build-validator.ts
@@ -31,7 +31,6 @@ export async function runBuildValidation(projectDir: string, timeoutMs: number =
     const args = pm === 'npm' ? ['run', 'build'] : ['build'];
     const proc = spawn(pm, args, {
       cwd: projectDir,
-      shell: true,
       timeout: timeoutMs,
     });
 

--- a/src/lib/validation/quick-checks.ts
+++ b/src/lib/validation/quick-checks.ts
@@ -223,7 +223,6 @@ function spawnCommand(
   return new Promise((resolve) => {
     const proc = spawn(command, args, {
       cwd,
-      shell: true,
       timeout: timeoutMs,
     });
 


### PR DESCRIPTION
## Summary

- **Fix agent loop**: The Next.js skill had ambiguous language about AuthKitProvider imports ("check README — it may be a subpath export") that caused the agent to repeatedly "find" and attempt to fix a correct import ~20 times. Hardcoded the import path (`@workos-inc/authkit-nextjs/components`) and added a note about the `getUser`→`withAuth` rename being version-dependent.
- **Fix DEP0190 warning**: Removed `shell: true` from `spawn()` calls in `build-validator.ts` and `quick-checks.ts`. Both already use the array-args form of `spawn(command, args)` which doesn't need a shell. Fixes `DeprecationWarning: Passing args to a child process with shell option true` on Node 25.

### Files Changed

- `skills/workos-authkit-nextjs/SKILL.md` — Unambiguous AuthKitProvider import, getUser/withAuth note
- `src/lib/validation/build-validator.ts` — Remove `shell: true`
- `src/lib/validation/quick-checks.ts` — Remove `shell: true`