### PR TITLE
fix(doctor): warn when AuthKitProvider missing apiHostname prop

### DIFF
--- a/src/doctor/checks/sdk.ts
+++ b/src/doctor/checks/sdk.ts
@@ -3,17 +3,12 @@ import { join } from 'node:path';
 import { readPackageJson, hasPackageInstalled, getPackageVersion } from '../../utils/package-json.js';
 import type { DoctorOptions, SdkInfo } from '../types.js';
 
-// AuthKit SDKs - check newer @workos/* scope first, then legacy @workos-inc/*
+// AuthKit SDKs - check @workos/* scope first, then @workos-inc/*
 const SDK_PACKAGES = [
-  // New @workos/* scope
-  '@workos/authkit-nextjs',
+  // @workos/* scope
   '@workos/authkit-tanstack-react-start',
-  '@workos/authkit-react-router',
-  '@workos/authkit-remix',
   '@workos/authkit-sveltekit',
-  '@workos/authkit-react',
-  '@workos/authkit-js',
-  // Legacy @workos-inc/* scope
+  // @workos-inc/* scope
   '@workos-inc/authkit-nextjs',
   '@workos-inc/authkit-remix',
   '@workos-inc/authkit-react-router',
@@ -24,13 +19,8 @@ const SDK_PACKAGES = [
 ] as const;
 
 const AUTHKIT_PACKAGES = new Set([
-  '@workos/authkit-nextjs',
   '@workos/authkit-tanstack-react-start',
-  '@workos/authkit-react-router',
-  '@workos/authkit-remix',
   '@workos/authkit-sveltekit',
-  '@workos/authkit-react',
-  '@workos/authkit-js',
   '@workos-inc/authkit-nextjs',
   '@workos-inc/authkit-remix',
   '@workos-inc/authkit-react-router',


### PR DESCRIPTION
## Summary

- Adds `MISSING_API_HOSTNAME` warning to `workos doctor` for React SPA SDK users (`@workos-inc/authkit-react`)
- Warns when `AuthKitProvider` is used without the `apiHostname` prop, which causes authorize requests to route through `api.workos.com` instead of the customer's custom authentication domain
- Server-side SDKs (Next.js, React Router, TanStack Start) are excluded — they use the `WORKOS_API_HOSTNAME` env var instead
- Removes phantom `@workos/*` packages from SDK detection that don't exist on npm