### PR TITLE
ci: add Socket Tier 1 Reachability Analysis workflow

### DIFF
--- a/.github/workflows/socket-tier1-analysis.yml
+++ b/.github/workflows/socket-tier1-analysis.yml
@@ -1,0 +1,40 @@
+name: Socket Tier 1 Reachability Analysis
+
+on:
+  schedule:
+    # every day at 12 AM
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Manually run vulnerability analysis'
+      distinct_id:
+        description: 'Required by the return-dispatch action'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  socket-vulnerability-analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check distinct_id
+        run: |
+          echo "distinct_id: ${{ github.event.inputs.distinct_id }}"
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Socket CLI
+        run: npm install -g socket
+      - name: Run Tier 1 reachability scan
+        env:
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_API_KEY }}
+        run: |
+          # Full application reachability (Tier 1)
+          socket scan create . \
+            --reach \
+            --org "workos" \
+            --no-interactive


### PR DESCRIPTION
## Summary

Adds the Socket Tier 1 Reachability Analysis GitHub Actions workflow to the CLI repo, matching the existing workflow in authkit-nextjs. The workflow runs a daily Socket security scan (cron at midnight UTC) with manual dispatch support, using `socket scan create --reach` for full application reachability analysis against the workos org. Requires the `SOCKET_API_KEY` secret.

## Changes

- Added `.github/workflows/socket-tier1-analysis.yml` — byte-for-byte identical to the authkit-nextjs reference workflow

## What was tested

### Automated

- Full test suite: **1153 tests passing** across 78 test files
- TypeScript typecheck: clean
- Build: clean
- No regressions introduced (workflow-only change, no source code modified)

### Manual

- YAML structure validated via scenario script:
  - ✅ Workflow name: "Socket Tier 1 Reachability Analysis"
  - ✅ Schedule: Daily cron at midnight (`0 0 * * *`)
  - ✅ `workflow_dispatch` with `tags` and `distinct_id` inputs (`distinct_id` required)
  - ✅ Concurrency: group by workflow + ref, cancel-in-progress
  - ✅ Job: `ubuntu-latest`, 60min timeout
  - ✅ Steps: All 4 steps (distinct_id check, checkout@v4, install socket, scan with `--reach --org --no-interactive`)
  - ✅ Env: `SOCKET_SECURITY_API_TOKEN` from `secrets.SOCKET_API_KEY`
  - ✅ Byte-for-byte identical to authkit-nextjs reference workflow

## Verification

This is a CI workflow file addition — no UI or runtime behavior to screenshot. Verification was performed by parsing the YAML and comparing against the known-good authkit-nextjs reference workflow. All 8 structural checks passed and the file is byte-for-byte identical to the reference.

## Follow-ups

None