### PR TITLE
fix: use prerelease versioning strategy for beta releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
-      "versioning": "default",
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta"
     }


### PR DESCRIPTION
## Summary
- Changes `versioning` from `"default"` to `"prerelease"` in release-please config
- The `default` strategy silently ignores `prerelease` and `prerelease-type` fields — only the `prerelease` strategy reads them
- Fixes #103 producing `0.12.0` instead of `0.12.0-beta`

## Notes
- First release after this merges will produce `0.12.0-beta`, subsequent bumps will be `0.12.0-beta.1`, `beta.2`, etc.
- PR #103 should be closed — release-please will regenerate it with the correct version after this merges