### PR TITLE
fix: stop reading WORKOS_CLIENT_ID for CLI auth

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -322,7 +322,6 @@ interface EnvVarInfo {
 
 const ENV_VAR_CATALOG: { name: string; effect: string }[] = [
   { name: 'WORKOS_API_KEY', effect: 'Bypasses credential resolution — used directly for API calls' },
-  { name: 'WORKOS_CLIENT_ID', effect: 'Overrides client ID from settings' },
   { name: 'WORKOS_FORCE_TTY', effect: 'Forces human (non-JSON) output mode, even when piped' },
   { name: 'WORKOS_NO_PROMPT', effect: 'Forces non-interactive/JSON mode' },
   { name: 'WORKOS_TELEMETRY', effect: 'Set to "false" to disable telemetry' },

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -106,11 +106,6 @@ export async function provisionStagingEnvironment(accessToken: string): Promise<
 export async function runLogin(): Promise<void> {
   const clientId = getCliAuthClientId();
 
-  if (!clientId) {
-    clack.log.error('CLI auth not configured. Set WORKOS_CLI_CLIENT_ID environment variable.');
-    process.exit(1);
-  }
-
   // Check if already logged in with valid token
   if (getAccessToken()) {
     const creds = getCredentials();

--- a/src/lib/run-with-core.ts
+++ b/src/lib/run-with-core.ts
@@ -329,10 +329,6 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
         const clientId = getCliAuthClientId();
         const authkitDomain = getAuthkitDomain();
 
-        if (!clientId) {
-          throw new Error('CLI auth not configured. Set WORKOS_CLI_CLIENT_ID environment variable.');
-        }
-
         const deviceAuth = await requestDeviceCode({
           clientId,
           authkitDomain,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -60,7 +60,7 @@ export function getConfig(): InstallerConfig {
  * Env var overrides config default.
  */
 export function getCliAuthClientId(): string {
-  return process.env.WORKOS_CLIENT_ID || config.workos.clientId;
+  return config.workos.clientId;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `getCliAuthClientId()` was reading `WORKOS_CLIENT_ID` from the environment to resolve the CLI's OAuth client ID. This collides with the same env var that every WorkOS-integrated app sets for its own client ID.
- When a user has `WORKOS_CLIENT_ID` set (common for any WorkOS developer), `workos auth login` sends their app's client ID to the device auth endpoint, which returns **401** because that client doesn't have the `device_code` grant type.
- Fix: return the hardcoded CLI client ID directly — there's no reason for end users to override it.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (1525 tests)
- [x] `pnpm typecheck` passes
- [x] `WORKOS_CLIENT_ID=client_01BOGUS workos auth login` no longer returns 401
- [x] `workos auth login` (no env override) still works as before