### PR TITLE
fix: prevent workos auth login from hanging indefinitely

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,7 +11,7 @@ import type { CliConfig } from '../lib/config-store.js';
 import { formatWorkOSCommand } from '../utils/command-invocation.js';
 import { autoInstallSkills } from './install-skill.js';
 import { isJsonMode } from '../utils/output.js';
-import { requestDeviceCode, pollForToken, DeviceAuthError } from '../lib/device-auth.js';
+import { requestDeviceCode, pollForToken, DeviceAuthTimeoutError } from '../lib/device-auth.js';
 
 /**
  * Best-effort skill install after a successful auth-login.
@@ -167,7 +167,7 @@ export async function runLogin(): Promise<void> {
 
     await installSkillsAfterLogin();
   } catch (error) {
-    if (error instanceof DeviceAuthError && error.message.includes('timed out')) {
+    if (error instanceof DeviceAuthTimeoutError) {
       spinner.stop('Authentication timed out');
       clack.log.error('Authentication timed out. Please try again.');
     } else {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,66 +11,7 @@ import type { CliConfig } from '../lib/config-store.js';
 import { formatWorkOSCommand } from '../utils/command-invocation.js';
 import { autoInstallSkills } from './install-skill.js';
 import { isJsonMode } from '../utils/output.js';
-
-/**
- * Parse JWT payload
- */
-function parseJwt(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8'));
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Extract expiry time from JWT token
- */
-function getJwtExpiry(token: string): number | null {
-  const payload = parseJwt(token);
-  if (!payload || typeof payload.exp !== 'number') return null;
-  return payload.exp * 1000;
-}
-
-const POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
-/**
- * Get Connect OAuth endpoints from AuthKit domain
- */
-function getConnectEndpoints() {
-  const domain = getAuthkitDomain();
-  return {
-    deviceAuthorization: `${domain}/oauth2/device_authorization`,
-    token: `${domain}/oauth2/token`,
-  };
-}
-
-interface DeviceAuthResponse {
-  device_code: string;
-  user_code: string;
-  verification_uri: string;
-  verification_uri_complete: string;
-  expires_in: number;
-  interval: number;
-}
-
-interface ConnectTokenResponse {
-  access_token: string;
-  id_token: string;
-  token_type: string;
-  expires_in: number;
-  refresh_token?: string;
-}
-
-interface AuthErrorResponse {
-  error: string;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { requestDeviceCode, pollForToken, DeviceAuthError } from '../lib/device-auth.js';
 
 /**
  * Best-effort skill install after a successful auth-login.
@@ -169,28 +110,18 @@ export async function runLogin(): Promise<void> {
     }
   }
 
+  const authkitDomain = getAuthkitDomain();
+
   clack.log.step('Starting authentication...');
 
-  const endpoints = getConnectEndpoints();
-
-  const authResponse = await fetch(endpoints.deviceAuthorization, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      client_id: clientId,
-      scope: 'openid email staging-environment:credentials:read offline_access',
-    }),
-  });
-
-  if (!authResponse.ok) {
-    clack.log.error(`Failed to start authentication: ${authResponse.status}`);
+  let deviceAuth;
+  try {
+    deviceAuth = await requestDeviceCode({ clientId, authkitDomain });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    clack.log.error(`Failed to start authentication: ${msg}`);
     process.exit(1);
   }
-
-  const deviceAuth = (await authResponse.json()) as DeviceAuthResponse;
-  const pollIntervalMs = (deviceAuth.interval || 5) * 1000;
 
   clack.log.info(`\nOpen this URL in your browser:\n`);
   console.log(`  ${deviceAuth.verification_uri}`);
@@ -206,84 +137,44 @@ export async function runLogin(): Promise<void> {
   const spinner = clack.spinner();
   spinner.start('Waiting for authentication...');
 
-  const startTime = Date.now();
-  let currentInterval = pollIntervalMs;
+  try {
+    const result = await pollForToken(deviceAuth.device_code, {
+      clientId,
+      authkitDomain,
+      interval: deviceAuth.interval,
+    });
 
-  while (Date.now() - startTime < POLL_TIMEOUT_MS) {
-    await sleep(currentInterval);
+    const expiresInSec = Math.round((result.expiresAt - Date.now()) / 1000);
 
-    try {
-      const tokenResponse = await fetch(endpoints.token, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-          device_code: deviceAuth.device_code,
-          client_id: clientId,
-        }),
-      });
+    saveCredentials({
+      accessToken: result.accessToken,
+      expiresAt: result.expiresAt,
+      userId: result.userId,
+      email: result.email,
+      refreshToken: result.refreshToken,
+    });
 
-      const data = await tokenResponse.json();
+    spinner.stop('Authentication successful!');
+    clack.log.success(`Logged in as ${result.email || result.userId}`);
+    clack.log.info(`Token expires in ${expiresInSec} seconds`);
 
-      if (tokenResponse.ok) {
-        const result = data as ConnectTokenResponse;
-
-        // Parse user info from id_token JWT
-        const idTokenPayload = parseJwt(result.id_token);
-        const userId = (idTokenPayload?.sub as string) || 'unknown';
-        const email = (idTokenPayload?.email as string) || undefined;
-
-        // Extract actual expiry from access token JWT, fallback to response or 15 min
-        const jwtExpiry = getJwtExpiry(result.access_token);
-        const expiresAt =
-          jwtExpiry ?? (result.expires_in ? Date.now() + result.expires_in * 1000 : Date.now() + 15 * 60 * 1000);
-
-        const expiresInSec = Math.round((expiresAt - Date.now()) / 1000);
-
-        saveCredentials({
-          accessToken: result.access_token,
-          expiresAt,
-          userId,
-          email,
-          refreshToken: result.refresh_token,
-        });
-
-        spinner.stop('Authentication successful!');
-        clack.log.success(`Logged in as ${email || userId}`);
-        clack.log.info(`Token expires in ${expiresInSec} seconds`);
-
-        // Auto-provision staging environment
-        const provisioned = await provisionStagingEnvironment(result.access_token);
-        if (provisioned) {
-          clack.log.success('Staging environment configured automatically');
-        } else {
-          clack.log.info(chalk.dim('Run `workos env add` to configure an environment manually'));
-        }
-
-        // Best-effort skill install. Wrapped helper guarantees login never
-        // fails on skill errors.
-        await installSkillsAfterLogin();
-        return;
-      }
-
-      const errorData = data as AuthErrorResponse;
-      if (errorData.error === 'authorization_pending') continue;
-      if (errorData.error === 'slow_down') {
-        currentInterval += 5000;
-        continue;
-      }
-
-      spinner.stop('Authentication failed');
-      clack.log.error(`Authentication error: ${errorData.error}`);
-      process.exit(1);
-    } catch {
-      continue;
+    const provisioned = await provisionStagingEnvironment(result.accessToken);
+    if (provisioned) {
+      clack.log.success('Staging environment configured automatically');
+    } else {
+      clack.log.info(chalk.dim('Run `workos env add` to configure an environment manually'));
     }
-  }
 
-  spinner.stop('Authentication timed out');
-  clack.log.error('Authentication timed out. Please try again.');
-  process.exit(1);
+    await installSkillsAfterLogin();
+  } catch (error) {
+    if (error instanceof DeviceAuthError && error.message.includes('timed out')) {
+      spinner.stop('Authentication timed out');
+      clack.log.error('Authentication timed out. Please try again.');
+    } else {
+      spinner.stop('Authentication failed');
+      const msg = error instanceof Error ? error.message : String(error);
+      clack.log.error(`Authentication error: ${msg}`);
+    }
+    process.exit(1);
+  }
 }

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -119,7 +119,9 @@ export async function requestDeviceCode(options: DeviceAuthOptions): Promise<Dev
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw new DeviceAuthTimeoutError('Device authorization request timed out');
     }
-    throw new DeviceAuthError(`Device authorization request failed: ${error instanceof Error ? error.message : String(error)}`);
+    throw new DeviceAuthError(
+      `Device authorization request failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
   } finally {
     clearTimeout(timeout);
   }

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -54,6 +54,13 @@ export class DeviceAuthError extends Error {
   }
 }
 
+export class DeviceAuthTimeoutError extends DeviceAuthError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeviceAuthTimeoutError';
+  }
+}
+
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const DEFAULT_POLL_INTERVAL_SECONDS = 5;
 const POLL_REQUEST_TIMEOUT_MS = 30_000;
@@ -107,6 +114,12 @@ export async function requestDeviceCode(options: DeviceAuthOptions): Promise<Dev
       }),
       signal: controller.signal,
     });
+  } catch (error) {
+    clearTimeout(timeout);
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new DeviceAuthTimeoutError('Device authorization request timed out');
+    }
+    throw new DeviceAuthError(`Device authorization request failed: ${error instanceof Error ? error.message : String(error)}`);
   } finally {
     clearTimeout(timeout);
   }
@@ -204,7 +217,7 @@ export async function pollForToken(
   }
 
   logError('[device-auth] Authentication timed out, last poll:', lastPollSummary);
-  throw new DeviceAuthError(
+  throw new DeviceAuthTimeoutError(
     `Authentication timed out after ${Math.round(timeoutMs / 1000)} seconds (last token response: ${lastPollSummary})`,
   );
 }

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -94,14 +94,22 @@ export async function requestDeviceCode(options: DeviceAuthOptions): Promise<Dev
   const url = `${options.authkitDomain}/oauth2/device_authorization`;
 
   logInfo('[device-auth] Requesting device code from:', url);
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: options.clientId,
-      scope: scopes.join(' '),
-    }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), POLL_REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: options.clientId,
+        scope: scopes.join(' '),
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   logInfo('[device-auth] Device code response status:', res.status);
   if (!res.ok) {


### PR DESCRIPTION
## Summary

- **Fixes auth hang**: `workos auth login` could hang forever if a TCP connection stalled (proxy, captive portal, IPv6 sinkhole). The inline polling loop in `login.ts` had no `AbortController` on fetch requests, so a single hung connection defeated the 5-minute outer timeout.
- **Deduplicates device auth**: `login.ts` reimplemented the entire device auth polling loop (JWT parsing, token handling, sleep, types) that already existed in `device-auth.ts`. The two had diverged -- `device-auth.ts` had a 30-second per-request abort timeout, `login.ts` did not. Refactored `runLogin` to call `requestDeviceCode` + `pollForToken` directly.
- **Abort on initial request too**: Added the same 30-second abort timeout to `requestDeviceCode`, which also lacked one.
- **Net -101 lines**: Removed ~158 lines of duplicated logic, added ~57 lines of integration code.

Reported via Slack by Fraser Langton -- CLI stuck on "Waiting for authentication..." after browser showed success.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (1621 tests)
- [x] `pnpm typecheck` passes
- [x] Manual test: `workos auth logout && workos auth login` completes successfully
- [x] Manual test: pointing CLI at a hanging server (`WORKOS_AUTHKIT_DOMAIN=http://127.0.0.1:9999`) aborts within 30s instead of hanging forever
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/cli/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Centralized device authorization and token polling for a more reliable login flow.
  * Improved timeout detection with a distinct timeout response and clearer messaging.
  * Consolidated error handling during polling to reduce confusing failures and exits.
  * Credential persistence updated to a normalized format for more consistent post-login state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->