### PR TITLE
fix: pass port and https flag to WorkOS SDK when base URL requires it

### DIFF
--- a/src/lib/workos-client.ts
+++ b/src/lib/workos-client.ts
@@ -60,9 +60,12 @@ export function createWorkOSClient(apiKey?: string, baseUrl?: string): WorkOSCLI
   const key = apiKey ?? resolveApiKey();
   const base = baseUrl ?? resolveApiBaseUrl();
 
-  // Parse hostname from base URL for SDK init
-  const hostname = new URL(base).hostname;
-  const sdk = new WorkOS(key, { apiHostname: hostname });
+  const url = new URL(base);
+  const sdk = new WorkOS(key, {
+    apiHostname: url.hostname,
+    ...(url.port && { port: Number(url.port) }),
+    ...(url.protocol === 'http:' && { https: false }),
+  });
 
   return {
     sdk,


### PR DESCRIPTION
I've been playing around a bit with the WorkOS emulator that's included in the CLI and started to grow on it, but it wasn't possible to run the CLI easily against the emulator.

Emulator runs by default on port `4100`.

```
workos env add \
    --name emulator \
    --api-key sk_test_default \
    --endpoint http://localhost:4100
```

Using the cli with the env above would result for any command in

```
Unexpected error: TypeError: fetch failed
```

since it would try to talk to `localhost:443` as the 443 is populated by the SDK, probably also had some issues with protocol.
The description of `endpoint` does not suggest anything against my understanding of the value.

```
--endpoint Custom API endpoint [string]`
```

Tested it locally:
```
# ./dist/bin.js env list
    Name                     Type          Endpoint
▸   emulator                 Sandbox       http://localhost:4100
```

```
# ./dist/bin.js org list
ID                              Name     Domains
───────────────────────────────────────────────────
org_01KQSNC2T5N9BXRCV4RYWTXTF1  Example  example.com
```

Probably could take this even further and say that by default it runs against itself but that's maybe room for improvement from maintainer site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WorkOS client URL initialization to properly handle hostname, port, and protocol configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->