### PR TITLE
ci: add PR title linting for conventional commits

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `lint-pr-title.yml` GitHub Actions workflow to enforce conventional commit format on PR titles
- Uses `amannn/action-semantic-pull-request@v6` (pinned to SHA), matching the setup in authkit-nextjs
- Runs on `pull_request_target` events (opened, edited, synchronize)

## Test plan

- [x] Workflow file matches authkit-nextjs configuration
- [ ] Verify the action runs on this PR (title uses `ci:` prefix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/cli/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request title validation to maintain consistent commit message standards across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/cli/pull/150)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->