### PR TITLE
fix: bump @workos/skills to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@napi-rs/keyring": "^1.2.0",
     "@workos-inc/node": "^8.7.0",
     "@workos/openapi-spec": "^0.1.0",
-    "@workos/skills": "0.5.0",
+    "@workos/skills": "0.6.0",
     "chalk": "^5.6.2",
     "diff": "^8.0.3",
     "fast-glob": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       '@workos/skills':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1077,8 +1077,8 @@ packages:
   '@workos/openapi-spec@0.1.0':
     resolution: {integrity: sha512-pVw8SPFsva6UR8Z2ovE1DC4Aq1fRdPXywT8JP7yN1G8Y02+/kDb6KgFXmpKiv76XinUXDOAmU9tr/G73UI8mHw==}
 
-  '@workos/skills@0.5.0':
-    resolution: {integrity: sha512-fScc+usjjvpyIOqSDq3AVmRpgpB5+yhyNfiqlSI/NsENe9C7Ynmbzx+XYwMJzGXpKIdUQQBHbvYRMOA1L+mWyw==}
+  '@workos/skills@0.6.0':
+    resolution: {integrity: sha512-BhXpbAyIWRsd8hm97zAGdlfQ+bbjJpgBtmPZckVny5+3mXOSVFqIxY+vwa5mSqkd2N2PYTd/Q+CD7Or0vWE28Q==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -2523,7 +2523,7 @@ snapshots:
 
   '@workos/openapi-spec@0.1.0': {}
 
-  '@workos/skills@0.5.0':
+  '@workos/skills@0.6.0':
     dependencies:
       yaml: 2.8.3
 


### PR DESCRIPTION
## Summary
- Bumps `@workos/skills` from 0.5.0 to 0.6.0

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/cli/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@workos/skills` dependency to version 0.6.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/cli/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->