### PR TITLE
fix: Make migrations API key optional

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2407,10 +2407,10 @@ yargs(rawArgs)
         }),
     async (argv) => {
       await applyInsecureStorage(argv.insecureStorage);
-      const { resolveApiKey } = await import('./lib/api-key.js');
+      const { resolveOptionalApiKey } = await import('./lib/api-key.js');
       const { getMigrationsPassthroughArgs, runMigrations } = await import('./commands/migrations.js');
       const passthrough = getMigrationsPassthroughArgs(rawArgs);
-      await runMigrations(passthrough, resolveApiKey({ apiKey: argv.apiKey }));
+      await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }));
     },
   )
   .command(

--- a/src/commands/migrations.spec.ts
+++ b/src/commands/migrations.spec.ts
@@ -20,6 +20,12 @@ describe('runMigrations', () => {
     expect(process.env.WORKOS_SECRET_KEY).toBe('sk_test_123');
   });
 
+  it('does not require WORKOS_SECRET_KEY when no API key is provided', async () => {
+    await runMigrations(['wizard']);
+    expect(process.env.WORKOS_SECRET_KEY).toBeUndefined();
+    expect(mockParseAsync).toHaveBeenCalledWith(['wizard'], { from: 'user' });
+  });
+
   it('delegates to Commander parseAsync with correct args', async () => {
     await runMigrations(['import', '--csv', 'users.csv'], 'sk_test_123');
     expect(mockParseAsync).toHaveBeenCalledWith(['import', '--csv', 'users.csv'], { from: 'user' });

--- a/src/commands/migrations.ts
+++ b/src/commands/migrations.ts
@@ -43,8 +43,10 @@ export function getMigrationsPassthroughArgs(rawArgs: string[]): string[] {
   return passthrough;
 }
 
-export async function runMigrations(args: string[], apiKey: string): Promise<void> {
-  process.env.WORKOS_SECRET_KEY = apiKey;
+export async function runMigrations(args: string[], apiKey?: string): Promise<void> {
+  if (apiKey) {
+    process.env.WORKOS_SECRET_KEY = apiKey;
+  }
 
   const { program } = (await import('@workos/migrations/dist/cli/index.js')) as {
     program: {

--- a/src/lib/api-key.spec.ts
+++ b/src/lib/api-key.spec.ts
@@ -39,7 +39,7 @@ vi.mock('node:os', async (importOriginal) => {
 });
 
 const { saveConfig, setInsecureConfigStorage, clearConfig } = await import('./config-store.js');
-const { resolveApiKey, resolveApiBaseUrl } = await import('./api-key.js');
+const { resolveApiKey, resolveOptionalApiKey, resolveApiBaseUrl } = await import('./api-key.js');
 
 describe('api-key', () => {
   const originalEnv = process.env;
@@ -114,6 +114,22 @@ describe('api-key', () => {
         environments: { prod: { name: 'prod', type: 'production', apiKey: 'sk_stored' } },
       });
       expect(resolveApiKey({ apiKey: '' })).toBe('sk_stored');
+    });
+  });
+
+  describe('resolveOptionalApiKey', () => {
+    it('returns undefined when no API key is available', () => {
+      mockExitWithError.mockClear();
+      expect(resolveOptionalApiKey()).toBeUndefined();
+      expect(mockExitWithError).not.toHaveBeenCalled();
+    });
+
+    it('returns configured API key when available', () => {
+      saveConfig({
+        activeEnvironment: 'prod',
+        environments: { prod: { name: 'prod', type: 'production', apiKey: 'sk_stored' } },
+      });
+      expect(resolveOptionalApiKey()).toBe('sk_stored');
     });
   });
 

--- a/src/lib/api-key.spec.ts
+++ b/src/lib/api-key.spec.ts
@@ -118,6 +118,24 @@ describe('api-key', () => {
   });
 
   describe('resolveOptionalApiKey', () => {
+    it('returns --api-key flag over env var and stored key', () => {
+      process.env.WORKOS_API_KEY = 'sk_env_var';
+      saveConfig({
+        activeEnvironment: 'prod',
+        environments: { prod: { name: 'prod', type: 'production', apiKey: 'sk_stored' } },
+      });
+      expect(resolveOptionalApiKey({ apiKey: 'sk_flag' })).toBe('sk_flag');
+    });
+
+    it('returns WORKOS_API_KEY env var when no flag provided', () => {
+      process.env.WORKOS_API_KEY = 'sk_env_var';
+      saveConfig({
+        activeEnvironment: 'prod',
+        environments: { prod: { name: 'prod', type: 'production', apiKey: 'sk_stored' } },
+      });
+      expect(resolveOptionalApiKey()).toBe('sk_env_var');
+    });
+
     it('returns undefined when no API key is available', () => {
       mockExitWithError.mockClear();
       expect(resolveOptionalApiKey()).toBeUndefined();

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -17,6 +17,16 @@ export interface ApiKeyOptions {
 }
 
 export function resolveApiKey(options?: ApiKeyOptions): string {
+  const apiKey = resolveOptionalApiKey(options);
+  if (apiKey) return apiKey;
+
+  exitWithError({
+    code: 'no_api_key',
+    message: 'No API key configured. Run `workos env add` to configure an environment, or set WORKOS_API_KEY.',
+  });
+}
+
+export function resolveOptionalApiKey(options?: ApiKeyOptions): string | undefined {
   if (options?.apiKey) return options.apiKey;
 
   const envVar = process.env.WORKOS_API_KEY;
@@ -25,10 +35,7 @@ export function resolveApiKey(options?: ApiKeyOptions): string {
   const activeEnv = getActiveEnvironment();
   if (activeEnv?.apiKey) return activeEnv.apiKey;
 
-  exitWithError({
-    code: 'no_api_key',
-    message: 'No API key configured. Run `workos env add` to configure an environment, or set WORKOS_API_KEY.',
-  });
+  return undefined;
 }
 
 export function resolveApiBaseUrl(): string {


### PR DESCRIPTION
## Summary
- Add optional API key resolution for commands that can run without credentials.
- Stop resolving a required WorkOS API key before delegating to `@workos/migrations`.
- Only set `WORKOS_SECRET_KEY` for migrations when an API key is configured or passed.

## Review & Testing Checklist for Human
- [ ] Verify `npx workos migrations wizard` opens the migration wizard without a configured WorkOS API key.
- [ ] Verify WorkOS-importing migration flows still receive `WORKOS_SECRET_KEY` when `--api-key`, `WORKOS_API_KEY`, or an active environment is configured.

### Notes
Tested locally with:
- `pnpm vitest run src/commands/migrations.spec.ts src/lib/api-key.spec.ts`
- `pnpm tsc --noEmit`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `env -u WORKOS_API_KEY HOME="/home/ubuntu/repos/cli/.devin-empty-home" timeout 3s ./dist/bin.js migrations wizard`

Link to Devin session: https://app.devin.ai/sessions/f4c9c2c328ff472fbc1ec993e28380ac
Requested by: @jonatascastro12
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/cli/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrations command now supports running without an explicit API key, allowing optional authentication.

* **Behavior Changes**
  * API key resolution now cleanly returns no value when none is provided and only sets credentials when an API key is supplied.

* **Tests**
  * Added tests covering migrations and API key resolution when no API key is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/cli/pull/153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->