### PR TITLE
fix(doctor): point COOKIE_DOMAIN_NOT_SET at a real docs URL

### DIFF
--- a/src/doctor/issues.ts
+++ b/src/doctor/issues.ts
@@ -23,7 +23,7 @@ export const ISSUE_DEFINITIONS = {
     severity: 'warning' as const,
     message: 'Cookie domain not explicitly set',
     remediation: 'Consider setting WORKOS_COOKIE_DOMAIN for cross-subdomain auth',
-    docsUrl: 'https://workos.com/docs/authkit/cookie-domain',
+    docsUrl: 'https://github.com/workos/authkit-nextjs#optional-configuration',
   },
   NO_SDK_FOUND: {
     severity: 'error' as const,


### PR DESCRIPTION
## Summary

`workos doctor` emits the warning below when AuthKit is detected and `WORKOS_COOKIE_DOMAIN` isn't set:

```
! COOKIE_DOMAIN_NOT_SET: Cookie domain not explicitly set
   → Consider setting WORKOS_COOKIE_DOMAIN for cross-subdomain auth
   Docs: https://workos.com/docs/authkit/cookie-domain
```

That docs URL 404s — there is no `/authkit/cookie-domain` page in the WorkOS docs. The env var is canonically documented in the `authkit-nextjs` README ("Optional configuration" section). This PR repoints the `docsUrl` there so the recommendation is actionable.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1800/1800)
- [x] `pnpm build` passes
- [x] Manually opened the new URL — `https://github.com/workos/authkit-nextjs#optional-configuration` resolves to the table that documents `WORKOS_COOKIE_DOMAIN`

## Note on related broken URLs

While verifying, I noticed a few other `workos.com/docs/authkit/*` URLs in this file (and in `src/doctor/checks/auth-patterns.ts`) that also 404 today:

- `https://workos.com/docs/authkit/redirect-uri` (issues.ts:42, auth-patterns.ts:324)
- `https://workos.com/docs/authkit/sign-out` (auth-patterns.ts:139)
- `https://workos.com/docs/authkit/nextjs/middleware` (auth-patterns.ts:194, 216)
- `https://workos.com/docs/authkit/nextjs/setup` (auth-patterns.ts:254)

Left out of this PR to keep the change surgical — happy to do a follow-up that audits all `docsUrl` fields against the live docs site if that's wanted.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references for cookie domain configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/cli/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->