### PR TITLE
docs: Add migrations command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ workos migrations export-template oidc_connections --output oidc_connections.csv
 workos migrations export-auth0 --domain your-tenant.auth0.com --token <token>
 
 # Import users from CSV
-workos migrations import --file users.csv
+workos migrations import --csv users.csv
 ```
 
 Run `workos migrations --help` for all available subcommands.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Resource Management:
   api-key                Manage per-org API keys
   org-domain             Manage organization domains
 
+Migrations:
+  migrations             Migrate users and SSO connections into WorkOS
+
 Workflows:
   seed                   Declarative resource provisioning from YAML
   setup-org              One-shot organization onboarding
@@ -195,6 +198,27 @@ Inspects a directory's sync state, user/group counts, recent events, and detects
 ```bash
 workos debug-sync directory_01ABC123
 ```
+
+### Migrations
+
+Migrate users and SSO connections from other identity providers into WorkOS. The `migrations` namespace passes through to `@workos/migrations`.
+
+```bash
+# Interactive migration wizard
+workos migrations wizard
+
+# Export a blank CSV template
+workos migrations export-template saml_connections --output saml_connections.csv
+workos migrations export-template oidc_connections --output oidc_connections.csv
+
+# Export from Auth0
+workos migrations export-auth0 --domain your-tenant.auth0.com --token <token>
+
+# Import users from CSV
+workos migrations import --file users.csv
+```
+
+Run `workos migrations --help` for all available subcommands.
 
 <!-- UNRELEASED: Local Development (emulator) — hidden until beta testing is complete.
      To restore, uncomment this section and re-enable the `emulate` and `dev` commands

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ workos migrations export-template saml_connections --output saml_connections.csv
 workos migrations export-template oidc_connections --output oidc_connections.csv
 
 # Export from Auth0
-workos migrations export-auth0 --domain your-tenant.auth0.com --token <token>
+workos migrations export-auth0 --domain your-tenant.auth0.com --client-id <id> --client-secret <secret>
 
 # Import users from CSV
 workos migrations import --csv users.csv


### PR DESCRIPTION
## Summary

Adds the `migrations` command/namespace to the CLI README:
- Listed in the command overview under a new "Migrations" category
- New `### Migrations` section with usage examples (`wizard`, `export-template`, `export-auth0`, `import`)

## Review & Testing Checklist for Human

- [ ] Verify the listed subcommands match what `workos migrations --help` actually shows

### Notes

Docs-only change — no code modified.

Link to Devin session: https://app.devin.ai/sessions/f5a65dfe04c34a4c804b7c1d158c1ee0
Requested by: @jonatascastro12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented new Migrations resource group in CLI resource management
  * Added migration guide for users and SSO connections (SAML/OIDC) into WorkOS
  * Included example workflows: interactive setup wizard, CSV template exports, Auth0 migration, and user CSV imports
  * Complete migration subcommands available via `migrations --help`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/cli/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->