### PR TITLE
feat: Forward endpoint URL to migrations package

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2408,10 +2408,10 @@ yargs(rawArgs)
         }),
     async (argv) => {
       await applyInsecureStorage(argv.insecureStorage);
-      const { resolveOptionalApiKey } = await import('./lib/api-key.js');
+      const { resolveOptionalApiKey, resolveApiBaseUrl } = await import('./lib/api-key.js');
       const { getMigrationsPassthroughArgs, runMigrations } = await import('./commands/migrations.js');
       const passthrough = getMigrationsPassthroughArgs(rawArgs);
-      await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }));
+      await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }), resolveApiBaseUrl());
     },
   )
   .command(

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2408,10 +2408,12 @@ yargs(rawArgs)
         }),
     async (argv) => {
       await applyInsecureStorage(argv.insecureStorage);
-      const { resolveOptionalApiKey, resolveApiBaseUrl } = await import('./lib/api-key.js');
+      const { resolveOptionalApiKey } = await import('./lib/api-key.js');
+      const { getActiveEnvironment } = await import('./lib/config-store.js');
       const { getMigrationsPassthroughArgs, runMigrations } = await import('./commands/migrations.js');
       const passthrough = getMigrationsPassthroughArgs(rawArgs);
-      await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }), resolveApiBaseUrl());
+      const endpoint = getActiveEnvironment()?.endpoint;
+      await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }), endpoint);
     },
   )
   .command(

--- a/src/commands/migrations.spec.ts
+++ b/src/commands/migrations.spec.ts
@@ -13,6 +13,7 @@ describe('runMigrations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.WORKOS_SECRET_KEY;
+    delete process.env.WORKOS_API_URL;
   });
 
   it('sets WORKOS_SECRET_KEY from the provided API key', async () => {
@@ -40,6 +41,16 @@ describe('runMigrations', () => {
     const args = ['export-auth0', '--domain', 'example.auth0.com', '--client-id', 'abc', '--client-secret', 'xyz'];
     await runMigrations(args, 'sk_test_789');
     expect(mockParseAsync).toHaveBeenCalledWith(args, { from: 'user' });
+  });
+
+  it('sets WORKOS_API_URL when apiBaseUrl is provided', async () => {
+    await runMigrations(['import', '--csv', 'users.csv'], 'sk_test_123', 'https://api.staging.workos.com');
+    expect(process.env.WORKOS_API_URL).toBe('https://api.staging.workos.com');
+  });
+
+  it('does not set WORKOS_API_URL when apiBaseUrl is undefined', async () => {
+    await runMigrations(['import', '--csv', 'users.csv'], 'sk_test_123');
+    expect(process.env.WORKOS_API_URL).toBeUndefined();
   });
 
   it('removes WorkOS global flags from migrations passthrough args', () => {

--- a/src/commands/migrations.ts
+++ b/src/commands/migrations.ts
@@ -43,9 +43,12 @@ export function getMigrationsPassthroughArgs(rawArgs: string[]): string[] {
   return passthrough;
 }
 
-export async function runMigrations(args: string[], apiKey?: string): Promise<void> {
+export async function runMigrations(args: string[], apiKey?: string, apiBaseUrl?: string): Promise<void> {
   if (apiKey) {
     process.env.WORKOS_SECRET_KEY = apiKey;
+  }
+  if (apiBaseUrl) {
+    process.env.WORKOS_API_URL = apiBaseUrl;
   }
 
   const { program } = (await import('@workos/migrations/dist/cli/index.js')) as {


### PR DESCRIPTION
## Summary

The `workos migrations` wrapper previously only forwarded `WORKOS_SECRET_KEY` to the migrations package. Users with custom endpoints (staging, self-hosted) had no way to direct migration API calls to their target environment.

Now `runMigrations()` accepts an optional `apiBaseUrl` param (resolved from the CLI's active environment via `resolveApiBaseUrl()`). When present, it sets `WORKOS_API_URL` in the process env before invoking the migrations CLI — the migrations package reads this env var to configure the SDK client's `apiHostname`.

```diff
-await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }));
+await runMigrations(passthrough, resolveOptionalApiKey({ apiKey: argv.apiKey }), resolveApiBaseUrl());
```

Resolves https://linear.app/workos/issue/ENT-6103/fix-cli-gaps-found-in-200k-import-load-test

Link to Devin session: https://app.devin.ai/sessions/27dc2a764fe546458f3e28cf7f24bc28
Requested by: @jonatascastro12