### PR TITLE
feat: scaffold a Next.js app when installing in an empty directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ shell command cache.
 - **AI-Powered:** Uses Claude to intelligently adapt to your project structure
 - **Security-First:** Masks API keys, redacts from logs, saves to .env.local
 - **Smart Detection:** Auto-detects framework, package manager, router type
+- **Greenfield Scaffolding:** Run in an empty directory to scaffold a new Next.js app (via `create-next-app`) before wiring AuthKit
 - **Live Documentation:** Fetches latest SDK docs from WorkOS and GitHub
 - **Full Integration:** Creates routes, middleware, environment vars, and UI
 - **Agent & CI Ready:** Non-TTY auto-detection, JSON output, structured errors, headless installer with NDJSON streaming
@@ -576,6 +577,8 @@ workos install [options]
   --redirect-uri <uri>    Custom redirect URI
   --homepage-url <url>    Custom homepage URL
   --install-dir <path>    Installation directory
+  --scaffold              Scaffold a new Next.js app when run in an empty directory
+  --pm <manager>          Package manager for the scaffolded app: npm, pnpm, yarn, bun
   --no-validate           Skip post-installation validation
   --no-branch             Skip branch creation (use current branch)
   --no-commit             Skip auto-commit after installation
@@ -585,11 +588,16 @@ workos install [options]
   --debug                 Enable verbose logging
 ```
 
+**Empty directories:** Running `workos install` in an empty directory scaffolds a new Next.js app with `create-next-app` (App Router, TypeScript, Tailwind, `src/`) and then wires AuthKit into it. This only happens when the directory is empty or contains nothing but VCS/editor metadata (`.git`, `.gitignore`, `LICENSE`, `.idea`, and similar). Any project file — including a `README.md` or a `package.json` — opts out, and the installer treats the directory as an existing project. Interactive runs confirm first (default yes); non-interactive/headless runs (or `--scaffold`) scaffold automatically and report `"scaffolded": true`. The package manager is resolved from how you invoked the CLI (`npm_config_user_agent`) unless you pass `--pm`.
+
 ## Examples
 
 ```bash
 # Interactive (recommended)
 npx workos@latest install
+
+# Greenfield: scaffold a new Next.js app + AuthKit in an empty directory
+mkdir my-app && cd my-app && npx workos@latest install
 
 # Specify framework
 npx workos@latest install --integration react-router

--- a/README.md
+++ b/README.md
@@ -571,7 +571,6 @@ workos org-domain delete <id>
 workos install [options]
 
   --direct, -D            Use your own Anthropic API key (bypass llm-gateway)
-  --integration <name>    Framework: nextjs, react, react-router, tanstack-start, vanilla-js, sveltekit, node, python, ruby, go, dotnet, kotlin, elixir, php-laravel, php
   --api-key <key>         WorkOS API key (required in non-interactive mode)
   --client-id <id>        WorkOS client ID (required in non-interactive mode)
   --redirect-uri <uri>    Custom redirect URI
@@ -598,9 +597,6 @@ npx workos@latest install
 
 # Greenfield: scaffold a new Next.js app + AuthKit in an empty directory
 mkdir my-app && cd my-app && npx workos@latest install
-
-# Specify framework
-npx workos@latest install --integration react-router
 
 # With visual dashboard (experimental)
 npx workos@latest dashboard

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -235,6 +235,16 @@ const installerOptions = {
     describe: 'Check for dirty working tree (use --no-git-check to skip)',
     type: 'boolean' as const,
   },
+  scaffold: {
+    default: false,
+    describe: 'Scaffold a new Next.js app when run in an empty directory',
+    type: 'boolean' as const,
+  },
+  pm: {
+    describe: 'Package manager for the scaffolded app',
+    choices: ['npm', 'pnpm', 'yarn', 'bun'] as const,
+    type: 'string' as const,
+  },
 };
 
 // Check for updates (blocks up to 500ms, skip in JSON/non-human modes to keep machine streams clean)

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -200,10 +200,6 @@ const installerOptions = {
     describe: 'Directory to install WorkOS AuthKit in',
     type: 'string' as const,
   },
-  integration: {
-    describe: 'Integration to set up',
-    type: 'string' as const,
-  },
   'force-install': {
     default: false,
     describe: 'Force install packages even if peer dependency checks fail',

--- a/src/lib/adapters/cli-adapter.ts
+++ b/src/lib/adapters/cli-adapter.ts
@@ -21,6 +21,10 @@ export class CLIAdapter implements InstallerAdapter {
   private isStarted = false;
   private progress = new ProgressTracker();
 
+  // Scaffold (empty-dir) state, used to print a "next steps" hint on completion.
+  private scaffolded = false;
+  private scaffoldPackageManager = 'npm';
+
   // Store bound handlers for cleanup
   private handlers = new Map<string, (...args: unknown[]) => void>();
 
@@ -113,6 +117,13 @@ export class CLIAdapter implements InstallerAdapter {
     this.subscribe('validation:complete', this.handleValidationComplete);
     this.subscribe('complete', this.handleComplete);
     this.subscribe('error', this.handleError);
+    // Scaffold events (empty-directory app scaffolding)
+    this.subscribe('scaffold:prompt', this.handleScaffoldPrompt);
+    this.subscribe('scaffold:start', this.handleScaffoldStart);
+    this.subscribe('scaffold:progress', this.handleScaffoldProgress);
+    this.subscribe('scaffold:complete', this.handleScaffoldComplete);
+    this.subscribe('scaffold:failed', this.handleScaffoldFailed);
+
     // Branch check events
     this.subscribe('branch:prompt', this.handleBranchPrompt);
     this.subscribe('branch:created', this.handleBranchCreated);
@@ -397,6 +408,12 @@ export class CLIAdapter implements InstallerAdapter {
     console.log('');
     console.log(renderCompletionSummary(success, summary));
     console.log('');
+
+    // When we scaffolded a fresh app, the install ran in the current dir, so
+    // point the user straight at the dev server.
+    if (success && this.scaffolded) {
+      clack.log.info(`Start your app:  ${chalk.cyan(`${this.scaffoldPackageManager} run dev`)}`);
+    }
   };
 
   private handleError = ({ message, stack }: InstallerEvents['error']): void => {
@@ -437,6 +454,48 @@ export class CLIAdapter implements InstallerAdapter {
     if (stack && this.debug) {
       this.debugLog(stack);
     }
+  };
+
+  // ===== Scaffold Event Handlers =====
+
+  private handleScaffoldPrompt = async ({ packageManager }: InstallerEvents['scaffold:prompt']): Promise<void> => {
+    this.scaffoldPackageManager = packageManager;
+    this.isPromptActive = true;
+    const confirmed = await clack.confirm({
+      message: 'This directory is empty. Scaffold a new Next.js app with AuthKit here?',
+      initialValue: true,
+    });
+    this.isPromptActive = false;
+    this.flushPendingLogs();
+
+    this.sendEvent({
+      type: clack.isCancel(confirmed) || !confirmed ? 'SCAFFOLD_CANCELLED' : 'SCAFFOLD_CONFIRMED',
+    });
+  };
+
+  private handleScaffoldStart = ({ packageManager }: InstallerEvents['scaffold:start']): void => {
+    this.scaffoldPackageManager = packageManager;
+    this.spinner = clack.spinner();
+    this.spinner.start(`Scaffolding a new Next.js app with ${packageManager} (this can take a minute)...`);
+  };
+
+  // create-next-app output is verbose; surface it only under --debug and keep
+  // the spinner message stable so the CLI stays readable.
+  private handleScaffoldProgress = ({ text }: InstallerEvents['scaffold:progress']): void => {
+    const line = text.trim();
+    if (line) {
+      this.debugLog(line);
+    }
+  };
+
+  private handleScaffoldComplete = (): void => {
+    this.scaffolded = true;
+    this.stopSpinner('Next.js app created');
+  };
+
+  private handleScaffoldFailed = ({ error }: InstallerEvents['scaffold:failed']): void => {
+    this.stopSpinner('Scaffold failed');
+    clack.log.error(`Could not scaffold the app: ${error}`);
   };
 
   private handleBranchPrompt = async ({ branch }: InstallerEvents['branch:prompt']): Promise<void> => {

--- a/src/lib/adapters/cli-adapter.ts
+++ b/src/lib/adapters/cli-adapter.ts
@@ -118,7 +118,6 @@ export class CLIAdapter implements InstallerAdapter {
     this.subscribe('complete', this.handleComplete);
     this.subscribe('error', this.handleError);
     // Scaffold events (empty-directory app scaffolding)
-    this.subscribe('scaffold:notice', this.handleScaffoldNotice);
     this.subscribe('scaffold:prompt', this.handleScaffoldPrompt);
     this.subscribe('scaffold:start', this.handleScaffoldStart);
     this.subscribe('scaffold:progress', this.handleScaffoldProgress);
@@ -458,10 +457,6 @@ export class CLIAdapter implements InstallerAdapter {
   };
 
   // ===== Scaffold Event Handlers =====
-
-  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
-    this.queueableLog(() => clack.log.warn(message));
-  };
 
   private handleScaffoldPrompt = async ({ packageManager }: InstallerEvents['scaffold:prompt']): Promise<void> => {
     this.scaffoldPackageManager = packageManager;

--- a/src/lib/adapters/cli-adapter.ts
+++ b/src/lib/adapters/cli-adapter.ts
@@ -118,6 +118,7 @@ export class CLIAdapter implements InstallerAdapter {
     this.subscribe('complete', this.handleComplete);
     this.subscribe('error', this.handleError);
     // Scaffold events (empty-directory app scaffolding)
+    this.subscribe('scaffold:notice', this.handleScaffoldNotice);
     this.subscribe('scaffold:prompt', this.handleScaffoldPrompt);
     this.subscribe('scaffold:start', this.handleScaffoldStart);
     this.subscribe('scaffold:progress', this.handleScaffoldProgress);
@@ -457,6 +458,10 @@ export class CLIAdapter implements InstallerAdapter {
   };
 
   // ===== Scaffold Event Handlers =====
+
+  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
+    this.queueableLog(() => clack.log.warn(message));
+  };
 
   private handleScaffoldPrompt = async ({ packageManager }: InstallerEvents['scaffold:prompt']): Promise<void> => {
     this.scaffoldPackageManager = packageManager;

--- a/src/lib/adapters/dashboard-adapter.ts
+++ b/src/lib/adapters/dashboard-adapter.ts
@@ -50,6 +50,14 @@ export class DashboardAdapter implements InstallerAdapter {
     this.emitter.on('confirm:response', this.handleConfirmResponse);
     this.emitter.on('credentials:response', this.handleCredentialsResponse);
 
+    // Scaffold (empty-dir): the TUI has no dedicated scaffold prompt yet, so
+    // auto-proceed (the user ran the installer in an empty dir) and surface
+    // progress through the `status` event the Dashboard already renders.
+    this.emitter.on('scaffold:prompt', this.handleScaffoldPrompt);
+    this.emitter.on('scaffold:start', this.handleScaffoldStart);
+    this.emitter.on('scaffold:complete', this.handleScaffoldComplete);
+    this.emitter.on('scaffold:failed', this.handleScaffoldFailed);
+
     // Track completion for post-exit summary
     this.emitter.on('complete', this.handleComplete);
   }
@@ -67,6 +75,10 @@ export class DashboardAdapter implements InstallerAdapter {
     // Unsubscribe from events
     this.emitter.off('confirm:response', this.handleConfirmResponse);
     this.emitter.off('credentials:response', this.handleCredentialsResponse);
+    this.emitter.off('scaffold:prompt', this.handleScaffoldPrompt);
+    this.emitter.off('scaffold:start', this.handleScaffoldStart);
+    this.emitter.off('scaffold:complete', this.handleScaffoldComplete);
+    this.emitter.off('scaffold:failed', this.handleScaffoldFailed);
     this.emitter.off('complete', this.handleComplete);
 
     // Run cleanup (unmount Ink, exit fullscreen)
@@ -105,5 +117,23 @@ export class DashboardAdapter implements InstallerAdapter {
    */
   private handleCredentialsResponse = ({ apiKey, clientId }: { apiKey: string; clientId: string }): void => {
     this.sendEvent({ type: 'CREDENTIALS_SUBMITTED', apiKey, clientId });
+  };
+
+  // ===== Scaffold (empty-dir) handlers =====
+
+  private handleScaffoldPrompt = (): void => {
+    this.sendEvent({ type: 'SCAFFOLD_CONFIRMED' });
+  };
+
+  private handleScaffoldStart = ({ packageManager }: InstallerEvents['scaffold:start']): void => {
+    this.emitter.emit('status', { message: `Scaffolding a new Next.js app with ${packageManager}...` });
+  };
+
+  private handleScaffoldComplete = (): void => {
+    this.emitter.emit('status', { message: 'Next.js app created' });
+  };
+
+  private handleScaffoldFailed = ({ error }: InstallerEvents['scaffold:failed']): void => {
+    this.emitter.emit('status', { message: `Scaffold failed: ${error}` });
   };
 }

--- a/src/lib/adapters/dashboard-adapter.ts
+++ b/src/lib/adapters/dashboard-adapter.ts
@@ -53,6 +53,7 @@ export class DashboardAdapter implements InstallerAdapter {
     // Scaffold (empty-dir): the TUI has no dedicated scaffold prompt yet, so
     // auto-proceed (the user ran the installer in an empty dir) and surface
     // progress through the `status` event the Dashboard already renders.
+    this.emitter.on('scaffold:notice', this.handleScaffoldNotice);
     this.emitter.on('scaffold:prompt', this.handleScaffoldPrompt);
     this.emitter.on('scaffold:start', this.handleScaffoldStart);
     this.emitter.on('scaffold:complete', this.handleScaffoldComplete);
@@ -75,6 +76,7 @@ export class DashboardAdapter implements InstallerAdapter {
     // Unsubscribe from events
     this.emitter.off('confirm:response', this.handleConfirmResponse);
     this.emitter.off('credentials:response', this.handleCredentialsResponse);
+    this.emitter.off('scaffold:notice', this.handleScaffoldNotice);
     this.emitter.off('scaffold:prompt', this.handleScaffoldPrompt);
     this.emitter.off('scaffold:start', this.handleScaffoldStart);
     this.emitter.off('scaffold:complete', this.handleScaffoldComplete);
@@ -120,6 +122,10 @@ export class DashboardAdapter implements InstallerAdapter {
   };
 
   // ===== Scaffold (empty-dir) handlers =====
+
+  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
+    this.emitter.emit('status', { message });
+  };
 
   private handleScaffoldPrompt = (): void => {
     this.sendEvent({ type: 'SCAFFOLD_CONFIRMED' });

--- a/src/lib/adapters/dashboard-adapter.ts
+++ b/src/lib/adapters/dashboard-adapter.ts
@@ -53,7 +53,6 @@ export class DashboardAdapter implements InstallerAdapter {
     // Scaffold (empty-dir): the TUI has no dedicated scaffold prompt yet, so
     // auto-proceed (the user ran the installer in an empty dir) and surface
     // progress through the `status` event the Dashboard already renders.
-    this.emitter.on('scaffold:notice', this.handleScaffoldNotice);
     this.emitter.on('scaffold:prompt', this.handleScaffoldPrompt);
     this.emitter.on('scaffold:start', this.handleScaffoldStart);
     this.emitter.on('scaffold:complete', this.handleScaffoldComplete);
@@ -76,7 +75,6 @@ export class DashboardAdapter implements InstallerAdapter {
     // Unsubscribe from events
     this.emitter.off('confirm:response', this.handleConfirmResponse);
     this.emitter.off('credentials:response', this.handleCredentialsResponse);
-    this.emitter.off('scaffold:notice', this.handleScaffoldNotice);
     this.emitter.off('scaffold:prompt', this.handleScaffoldPrompt);
     this.emitter.off('scaffold:start', this.handleScaffoldStart);
     this.emitter.off('scaffold:complete', this.handleScaffoldComplete);
@@ -122,10 +120,6 @@ export class DashboardAdapter implements InstallerAdapter {
   };
 
   // ===== Scaffold (empty-dir) handlers =====
-
-  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
-    this.emitter.emit('status', { message });
-  };
 
   private handleScaffoldPrompt = (): void => {
     this.sendEvent({ type: 'SCAFFOLD_CONFIRMED' });

--- a/src/lib/adapters/headless-adapter.spec.ts
+++ b/src/lib/adapters/headless-adapter.spec.ts
@@ -293,6 +293,42 @@ describe('HeadlessAdapter', () => {
     });
   });
 
+  describe('scaffold events', () => {
+    it('streams scaffold:* and flags the completion as scaffolded', async () => {
+      const adapter = createAdapter();
+      await adapter.start();
+
+      emitter.emit('scaffold:checking', {});
+      emitter.emit('scaffold:start', { packageManager: 'pnpm' });
+      emitter.emit('scaffold:complete', {});
+      emitter.emit('complete', { success: true, summary: 'Installed' });
+
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({ type: 'scaffold:checking' });
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({ type: 'scaffold:start', packageManager: 'pnpm' });
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({ type: 'scaffold:complete' });
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({
+        type: 'complete',
+        success: true,
+        summary: 'Installed',
+        scaffolded: true,
+      });
+      await adapter.stop();
+    });
+
+    it('writes scaffold:failed with the error', async () => {
+      const adapter = createAdapter();
+      await adapter.start();
+
+      emitter.emit('scaffold:failed', { error: 'create-next-app exited with code 1' });
+
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({
+        type: 'scaffold:failed',
+        error: 'create-next-app exited with code 1',
+      });
+      await adapter.stop();
+    });
+  });
+
   describe('terminal events', () => {
     it('writes complete event', async () => {
       const adapter = createAdapter();
@@ -304,6 +340,7 @@ describe('HeadlessAdapter', () => {
         type: 'complete',
         success: true,
         summary: 'All done',
+        scaffolded: false,
       });
       await adapter.stop();
     });

--- a/src/lib/adapters/headless-adapter.spec.ts
+++ b/src/lib/adapters/headless-adapter.spec.ts
@@ -315,21 +315,6 @@ describe('HeadlessAdapter', () => {
       await adapter.stop();
     });
 
-    it('writes scaffold:notice', async () => {
-      const adapter = createAdapter();
-      await adapter.start();
-
-      emitter.emit('scaffold:notice', {
-        message: 'Scaffolding currently supports Next.js only; ignoring --integration react.',
-      });
-
-      expect(mockWriteNDJSON).toHaveBeenCalledWith({
-        type: 'scaffold:notice',
-        message: 'Scaffolding currently supports Next.js only; ignoring --integration react.',
-      });
-      await adapter.stop();
-    });
-
     it('writes scaffold:failed with the error', async () => {
       const adapter = createAdapter();
       await adapter.start();

--- a/src/lib/adapters/headless-adapter.spec.ts
+++ b/src/lib/adapters/headless-adapter.spec.ts
@@ -315,6 +315,21 @@ describe('HeadlessAdapter', () => {
       await adapter.stop();
     });
 
+    it('writes scaffold:notice', async () => {
+      const adapter = createAdapter();
+      await adapter.start();
+
+      emitter.emit('scaffold:notice', {
+        message: 'Scaffolding currently supports Next.js only; ignoring --integration react.',
+      });
+
+      expect(mockWriteNDJSON).toHaveBeenCalledWith({
+        type: 'scaffold:notice',
+        message: 'Scaffolding currently supports Next.js only; ignoring --integration react.',
+      });
+      await adapter.stop();
+    });
+
     it('writes scaffold:failed with the error', async () => {
       const adapter = createAdapter();
       await adapter.start();

--- a/src/lib/adapters/headless-adapter.ts
+++ b/src/lib/adapters/headless-adapter.ts
@@ -29,6 +29,7 @@ export class HeadlessAdapter implements InstallerAdapter {
   private debug: boolean;
   private options: HeadlessOptions;
   private isStarted = false;
+  private scaffolded = false;
   private handlers = new Map<string, (...args: unknown[]) => void>();
 
   constructor(config: AdapterConfig & { options: HeadlessOptions }) {
@@ -45,6 +46,13 @@ export class HeadlessAdapter implements InstallerAdapter {
     // Auth events
     this.subscribe('auth:success', this.handleAuthSuccess);
     this.subscribe('auth:failure', this.handleAuthFailure);
+
+    // Scaffold events (empty-directory app scaffolding) — auto-routed, no prompt
+    this.subscribe('scaffold:checking', this.handleScaffoldChecking);
+    this.subscribe('scaffold:start', this.handleScaffoldStart);
+    this.subscribe('scaffold:progress', this.handleScaffoldProgress);
+    this.subscribe('scaffold:complete', this.handleScaffoldComplete);
+    this.subscribe('scaffold:failed', this.handleScaffoldFailed);
 
     // Detection events
     this.subscribe('detection:complete', this.handleDetectionComplete);
@@ -132,6 +140,30 @@ export class HeadlessAdapter implements InstallerAdapter {
   private handleAuthFailure = ({ message }: InstallerEvents['auth:failure']): void => {
     writeNDJSON({ type: 'auth:required', message });
     process.exit(ExitCode.AUTH_REQUIRED);
+  };
+
+  // ===== Scaffold Handlers (auto-routed) =====
+
+  private handleScaffoldChecking = (): void => {
+    writeNDJSON({ type: 'scaffold:checking' });
+  };
+
+  private handleScaffoldStart = ({ packageManager }: InstallerEvents['scaffold:start']): void => {
+    writeNDJSON({ type: 'scaffold:start', packageManager });
+  };
+
+  // create-next-app output is verbose; surface it only under --debug.
+  private handleScaffoldProgress = ({ text }: InstallerEvents['scaffold:progress']): void => {
+    this.debugLog(text);
+  };
+
+  private handleScaffoldComplete = (): void => {
+    this.scaffolded = true;
+    writeNDJSON({ type: 'scaffold:complete' });
+  };
+
+  private handleScaffoldFailed = ({ error }: InstallerEvents['scaffold:failed']): void => {
+    writeNDJSON({ type: 'scaffold:failed', error });
   };
 
   // ===== Detection Handlers =====
@@ -332,7 +364,7 @@ export class HeadlessAdapter implements InstallerAdapter {
   // ===== Terminal Events =====
 
   private handleComplete = ({ success, summary }: InstallerEvents['complete']): void => {
-    writeNDJSON({ type: 'complete', success, summary });
+    writeNDJSON({ type: 'complete', success, summary, scaffolded: this.scaffolded });
   };
 
   private handleError = ({ message, stack }: InstallerEvents['error']): void => {

--- a/src/lib/adapters/headless-adapter.ts
+++ b/src/lib/adapters/headless-adapter.ts
@@ -49,7 +49,6 @@ export class HeadlessAdapter implements InstallerAdapter {
 
     // Scaffold events (empty-directory app scaffolding) — auto-routed, no prompt
     this.subscribe('scaffold:checking', this.handleScaffoldChecking);
-    this.subscribe('scaffold:notice', this.handleScaffoldNotice);
     this.subscribe('scaffold:start', this.handleScaffoldStart);
     this.subscribe('scaffold:progress', this.handleScaffoldProgress);
     this.subscribe('scaffold:complete', this.handleScaffoldComplete);
@@ -147,10 +146,6 @@ export class HeadlessAdapter implements InstallerAdapter {
 
   private handleScaffoldChecking = (): void => {
     writeNDJSON({ type: 'scaffold:checking' });
-  };
-
-  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
-    writeNDJSON({ type: 'scaffold:notice', message });
   };
 
   private handleScaffoldStart = ({ packageManager }: InstallerEvents['scaffold:start']): void => {

--- a/src/lib/adapters/headless-adapter.ts
+++ b/src/lib/adapters/headless-adapter.ts
@@ -49,6 +49,7 @@ export class HeadlessAdapter implements InstallerAdapter {
 
     // Scaffold events (empty-directory app scaffolding) — auto-routed, no prompt
     this.subscribe('scaffold:checking', this.handleScaffoldChecking);
+    this.subscribe('scaffold:notice', this.handleScaffoldNotice);
     this.subscribe('scaffold:start', this.handleScaffoldStart);
     this.subscribe('scaffold:progress', this.handleScaffoldProgress);
     this.subscribe('scaffold:complete', this.handleScaffoldComplete);
@@ -146,6 +147,10 @@ export class HeadlessAdapter implements InstallerAdapter {
 
   private handleScaffoldChecking = (): void => {
     writeNDJSON({ type: 'scaffold:checking' });
+  };
+
+  private handleScaffoldNotice = ({ message }: InstallerEvents['scaffold:notice']): void => {
+    writeNDJSON({ type: 'scaffold:notice', message });
   };
 
   private handleScaffoldStart = ({ packageManager }: InstallerEvents['scaffold:start']): void => {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -61,6 +61,15 @@ export interface InstallerEvents {
   'validation:issues': { issues: import('./validation/types.js').ValidationIssue[] };
   'validation:complete': { passed: boolean; issueCount: number; durationMs: number };
 
+  // Scaffold events (empty-directory app scaffolding)
+  'scaffold:checking': Record<string, never>;
+  'scaffold:prompt': { packageManager: string };
+  'scaffold:start': { packageManager: string };
+  'scaffold:progress': { text: string };
+  'scaffold:complete': Record<string, never>;
+  'scaffold:failed': { error: string };
+  'scaffold:skipped': Record<string, never>;
+
   // Branch check events
   'branch:checking': Record<string, never>;
   'branch:protected': { branch: string };

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -63,6 +63,7 @@ export interface InstallerEvents {
 
   // Scaffold events (empty-directory app scaffolding)
   'scaffold:checking': Record<string, never>;
+  'scaffold:notice': { message: string };
   'scaffold:prompt': { packageManager: string };
   'scaffold:start': { packageManager: string };
   'scaffold:progress': { text: string };

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -63,7 +63,6 @@ export interface InstallerEvents {
 
   // Scaffold events (empty-directory app scaffolding)
   'scaffold:checking': Record<string, never>;
-  'scaffold:notice': { message: string };
   'scaffold:prompt': { packageManager: string };
   'scaffold:start': { packageManager: string };
   'scaffold:progress': { text: string };

--- a/src/lib/installer-core.events.spec.ts
+++ b/src/lib/installer-core.events.spec.ts
@@ -26,7 +26,13 @@ import { createActor, fromPromise } from 'xstate';
 import { installerMachine } from './installer-core.js';
 import { createEventCapture, compareEventSequences, filterDeterministicEvents } from './installer-core.test-utils.js';
 import type { InstallerOptions } from '../utils/types.js';
-import type { DetectionOutput, GitCheckOutput, AgentOutput, InstallerMachineContext } from './installer-core.types.js';
+import type {
+  DetectionOutput,
+  GitCheckOutput,
+  AgentOutput,
+  InstallerMachineContext,
+  WorkspaceCheckOutput,
+} from './installer-core.types.js';
 
 /**
  * Creates mock actor implementations for testing.
@@ -37,6 +43,13 @@ import type { DetectionOutput, GitCheckOutput, AgentOutput, InstallerMachineCont
 function createMockActors() {
   return {
     checkAuthentication: fromPromise<boolean, { options: InstallerOptions }>(async () => true),
+    // Default: not an empty dir, so the scaffold state falls straight through.
+    checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async () => ({
+      scaffoldable: false,
+      packageManager: 'npm',
+      autoScaffold: false,
+    })),
+    runScaffold: fromPromise<void, { context: InstallerMachineContext }>(async () => {}),
     detectIntegration: fromPromise<DetectionOutput, { options: InstallerOptions }>(async () => ({
       integration: 'nextjs',
     })),

--- a/src/lib/installer-core.spec.ts
+++ b/src/lib/installer-core.spec.ts
@@ -468,6 +468,7 @@ describe('InstallerCore State Machine', () => {
     function createScaffoldActor(opts: {
       workspace: WorkspaceCheckOutput;
       runScaffoldImpl?: () => Promise<void>;
+      integration?: string;
     }) {
       const emitter = createInstallerEventEmitter();
       const options: InstallerOptions = {
@@ -478,6 +479,7 @@ describe('InstallerCore State Machine', () => {
         ci: false,
         skipAuth: true,
         dashboard: false,
+        integration: opts.integration,
         emitter,
       };
 
@@ -586,6 +588,49 @@ describe('InstallerCore State Machine', () => {
       expect(ran).toBe(false);
       expect(skipped).toBe(true);
       expect(actor.getSnapshot().value).toBe('cancelled');
+      actor.stop();
+    });
+
+    it('warns but still scaffolds when --integration is not Next.js', async () => {
+      let ran = false;
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: true },
+        integration: 'react',
+        runScaffoldImpl: async () => {
+          ran = true;
+        },
+      });
+      const notices: string[] = [];
+      emitter.on('scaffold:notice', ({ message }) => notices.push(message));
+      emitter.on('error', () => {});
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(notices).toHaveLength(1);
+      expect(notices[0]).toContain('react');
+      expect(ran).toBe(true); // v1 still scaffolds Next.js
+      actor.stop();
+    });
+
+    it('does not warn when --integration is nextjs', async () => {
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: true },
+        integration: 'nextjs',
+        runScaffoldImpl: async () => {},
+      });
+      let noticed = false;
+      emitter.on('scaffold:notice', () => {
+        noticed = true;
+      });
+      emitter.on('error', () => {});
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(noticed).toBe(false);
       actor.stop();
     });
 

--- a/src/lib/installer-core.spec.ts
+++ b/src/lib/installer-core.spec.ts
@@ -468,7 +468,6 @@ describe('InstallerCore State Machine', () => {
     function createScaffoldActor(opts: {
       workspace: WorkspaceCheckOutput;
       runScaffoldImpl?: () => Promise<void>;
-      integration?: string;
     }) {
       const emitter = createInstallerEventEmitter();
       const options: InstallerOptions = {
@@ -479,7 +478,6 @@ describe('InstallerCore State Machine', () => {
         ci: false,
         skipAuth: true,
         dashboard: false,
-        integration: opts.integration,
         emitter,
       };
 
@@ -588,49 +586,6 @@ describe('InstallerCore State Machine', () => {
       expect(ran).toBe(false);
       expect(skipped).toBe(true);
       expect(actor.getSnapshot().value).toBe('cancelled');
-      actor.stop();
-    });
-
-    it('warns but still scaffolds when --integration is not Next.js', async () => {
-      let ran = false;
-      const { actor, emitter } = createScaffoldActor({
-        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: true },
-        integration: 'react',
-        runScaffoldImpl: async () => {
-          ran = true;
-        },
-      });
-      const notices: string[] = [];
-      emitter.on('scaffold:notice', ({ message }) => notices.push(message));
-      emitter.on('error', () => {});
-
-      actor.start();
-      actor.send({ type: 'START' });
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(notices).toHaveLength(1);
-      expect(notices[0]).toContain('react');
-      expect(ran).toBe(true); // v1 still scaffolds Next.js
-      actor.stop();
-    });
-
-    it('does not warn when --integration is nextjs', async () => {
-      const { actor, emitter } = createScaffoldActor({
-        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: true },
-        integration: 'nextjs',
-        runScaffoldImpl: async () => {},
-      });
-      let noticed = false;
-      emitter.on('scaffold:notice', () => {
-        noticed = true;
-      });
-      emitter.on('error', () => {});
-
-      actor.start();
-      actor.send({ type: 'START' });
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(noticed).toBe(false);
       actor.stop();
     });
 

--- a/src/lib/installer-core.spec.ts
+++ b/src/lib/installer-core.spec.ts
@@ -465,10 +465,7 @@ describe('InstallerCore State Machine', () => {
   });
 
   describe('scaffold flow', () => {
-    function createScaffoldActor(opts: {
-      workspace: WorkspaceCheckOutput;
-      runScaffoldImpl?: () => Promise<void>;
-    }) {
+    function createScaffoldActor(opts: { workspace: WorkspaceCheckOutput; runScaffoldImpl?: () => Promise<void> }) {
       const emitter = createInstallerEventEmitter();
       const options: InstallerOptions = {
         debug: false,
@@ -485,7 +482,9 @@ describe('InstallerCore State Machine', () => {
         actors: {
           ...baseMockActors,
           checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async () => opts.workspace),
-          runScaffold: fromPromise<void, { context: InstallerMachineContext }>(opts.runScaffoldImpl ?? (async () => {})),
+          runScaffold: fromPromise<void, { context: InstallerMachineContext }>(
+            opts.runScaffoldImpl ?? (async () => {}),
+          ),
         },
       });
 

--- a/src/lib/installer-core.spec.ts
+++ b/src/lib/installer-core.spec.ts
@@ -9,6 +9,7 @@ import type {
   AgentOutput,
   InstallerMachineContext,
   BranchCheckOutput,
+  WorkspaceCheckOutput,
 } from './installer-core.types.js';
 import type { EnvFileInfo } from './credential-discovery.js';
 import type { StagingCredentials } from './staging-api.js';
@@ -16,6 +17,13 @@ import type { StagingCredentials } from './staging-api.js';
 // Shared mock actors for reuse across tests
 const baseMockActors = {
   checkAuthentication: fromPromise<boolean, { options: InstallerOptions }>(async () => true),
+  // Default: not an empty dir, so the scaffold state falls straight through to preparing.
+  checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async () => ({
+    scaffoldable: false,
+    packageManager: 'npm',
+    autoScaffold: false,
+  })),
+  runScaffold: fromPromise<void, { context: InstallerMachineContext }>(async () => {}),
   detectIntegration: fromPromise<DetectionOutput, { options: InstallerOptions }>(async () => ({
     integration: 'nextjs',
   })),
@@ -37,7 +45,27 @@ const baseMockActors = {
   })),
 };
 
-function createTestActor(overrides?: Partial<InstallerOptions>) {
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Parallel-state actors that resolve slowly, so the `preparing` parallel snapshot
+// (detection/gitCheck/branchCheck all "running") is observable after a short wait.
+// Needed because the async scaffold gate now precedes `preparing`.
+const slowPreparingActors = {
+  detectIntegration: fromPromise<DetectionOutput, { options: InstallerOptions }>(async () => {
+    await delay(200);
+    return { integration: 'nextjs' };
+  }),
+  checkGitStatus: fromPromise<GitCheckOutput, { installDir: string }>(async () => {
+    await delay(200);
+    return { isClean: true, files: [] };
+  }),
+  checkBranch: fromPromise<BranchCheckOutput, void>(async () => {
+    await delay(200);
+    return { branch: 'main', isProtected: false };
+  }),
+};
+
+function createTestActor(overrides?: Partial<InstallerOptions>, actorOverrides?: Partial<typeof baseMockActors>) {
   const emitter = createInstallerEventEmitter();
   const options: InstallerOptions = {
     debug: false,
@@ -54,7 +82,7 @@ function createTestActor(overrides?: Partial<InstallerOptions>) {
 
   // Provide mock implementations for actors
   const machine = installerMachine.provide({
-    actors: baseMockActors,
+    actors: { ...baseMockActors, ...actorOverrides },
   });
 
   const actor = createActor(machine, {
@@ -83,11 +111,13 @@ describe('InstallerCore State Machine', () => {
       actor.stop();
     });
 
-    it('skips auth when skipAuth option is true', () => {
-      const { actor } = createTestActor({ skipAuth: true });
+    it('skips auth when skipAuth option is true', async () => {
+      const { actor } = createTestActor({ skipAuth: true }, slowPreparingActors);
       actor.start();
       actor.send({ type: 'START' });
-      // Should go directly to preparing (parallel state with detection, gitCheck, and branchCheck)
+      // The scaffold workspace-check runs first (async, instant); once it resolves
+      // not-scaffoldable, the machine lands in preparing (no authenticating state).
+      await delay(40);
       expect(actor.getSnapshot().value).toEqual({
         preparing: { detection: 'running', gitCheck: 'running', branchCheck: 'running' },
       });
@@ -97,9 +127,10 @@ describe('InstallerCore State Machine', () => {
 
   describe('parallel states', () => {
     it('runs detection, git check, and branch check in parallel', async () => {
-      const { actor } = createTestActor({ skipAuth: true });
+      const { actor } = createTestActor({ skipAuth: true }, slowPreparingActors);
       actor.start();
       actor.send({ type: 'START' });
+      await delay(40);
 
       // All three should be running in parallel
       const snapshot = actor.getSnapshot();
@@ -123,14 +154,16 @@ describe('InstallerCore State Machine', () => {
       actor.stop();
     });
 
-    it('emits state:enter for each state transition', () => {
+    it('emits state:enter for each state transition', async () => {
       const { actor, emitter } = createTestActor({ skipAuth: true });
       const states: string[] = [];
       emitter.on('state:enter', ({ state }) => states.push(state));
 
       actor.start();
       actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 50));
 
+      expect(states).toContain('scaffold');
       expect(states).toContain('preparing');
       actor.stop();
     });
@@ -427,6 +460,154 @@ describe('InstallerCore State Machine', () => {
 
       expect(deviceAuthStarted).toBe(false);
       expect(actor.getSnapshot().value).toBe('complete');
+      actor.stop();
+    });
+  });
+
+  describe('scaffold flow', () => {
+    function createScaffoldActor(opts: {
+      workspace: WorkspaceCheckOutput;
+      runScaffoldImpl?: () => Promise<void>;
+    }) {
+      const emitter = createInstallerEventEmitter();
+      const options: InstallerOptions = {
+        debug: false,
+        forceInstall: false,
+        installDir: '/test/project',
+        local: true,
+        ci: false,
+        skipAuth: true,
+        dashboard: false,
+        emitter,
+      };
+
+      const machine = installerMachine.provide({
+        actors: {
+          ...baseMockActors,
+          checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async () => opts.workspace),
+          runScaffold: fromPromise<void, { context: InstallerMachineContext }>(opts.runScaffoldImpl ?? (async () => {})),
+        },
+      });
+
+      const actor = createActor(machine, { input: { emitter, options } });
+      return { actor, emitter, options };
+    }
+
+    it('skips scaffolding when the directory is not empty', async () => {
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: false, packageManager: 'npm', autoScaffold: false },
+      });
+      const events: string[] = [];
+      emitter.on('scaffold:checking', () => events.push('scaffold:checking'));
+      emitter.on('scaffold:start', () => events.push('scaffold:start'));
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Checked the workspace, but never started a scaffold; fell through to the
+      // normal install path (left the scaffold state entirely).
+      expect(events).toEqual(['scaffold:checking']);
+      expect(actor.getSnapshot().context.scaffolded).toBeFalsy();
+      expect(actor.getSnapshot().matches('scaffold')).toBe(false);
+      actor.stop();
+    });
+
+    it('auto-scaffolds without prompting (headless / --scaffold)', async () => {
+      let ran = false;
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'pnpm', autoScaffold: true },
+        runScaffoldImpl: async () => {
+          ran = true;
+        },
+      });
+      const started: string[] = [];
+      emitter.on('scaffold:start', ({ packageManager }) => started.push(packageManager));
+      emitter.on('error', () => {});
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(ran).toBe(true);
+      expect(started).toEqual(['pnpm']);
+      expect(actor.getSnapshot().context.scaffolded).toBe(true);
+      actor.stop();
+    });
+
+    it('prompts then scaffolds on confirm', async () => {
+      let ran = false;
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: false },
+        runScaffoldImpl: async () => {
+          ran = true;
+        },
+      });
+      let prompted = false;
+      emitter.on('scaffold:prompt', () => {
+        prompted = true;
+      });
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(prompted).toBe(true);
+      expect(actor.getSnapshot().value).toMatchObject({ scaffold: 'prompting' });
+      expect(ran).toBe(false);
+
+      actor.send({ type: 'SCAFFOLD_CONFIRMED' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(ran).toBe(true);
+      actor.stop();
+    });
+
+    it('cancels without scaffolding when the prompt is declined', async () => {
+      let ran = false;
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: false },
+        runScaffoldImpl: async () => {
+          ran = true;
+        },
+      });
+      let skipped = false;
+      emitter.on('scaffold:skipped', () => {
+        skipped = true;
+      });
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      actor.send({ type: 'SCAFFOLD_CANCELLED' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(ran).toBe(false);
+      expect(skipped).toBe(true);
+      expect(actor.getSnapshot().value).toBe('cancelled');
+      actor.stop();
+    });
+
+    it('errors when create-next-app fails, preserving the message', async () => {
+      const { actor, emitter } = createScaffoldActor({
+        workspace: { scaffoldable: true, packageManager: 'npm', autoScaffold: true },
+        runScaffoldImpl: async () => {
+          throw new Error('create-next-app exited with code 1');
+        },
+      });
+      let failure: string | undefined;
+      emitter.on('scaffold:failed', ({ error }) => {
+        failure = error;
+      });
+      emitter.on('error', () => {});
+
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(actor.getSnapshot().value).toBe('error');
+      expect(failure).toContain('create-next-app exited with code 1');
       actor.stop();
     });
   });

--- a/src/lib/installer-core.ts
+++ b/src/lib/installer-core.ts
@@ -695,7 +695,19 @@ export const installerMachine = setup({
         {
           target: 'error',
           actions: [
-            assign({ error: () => new Error('Could not detect framework integration') }),
+            assign({
+              error: ({ context }) => {
+                const dir = context.options.installDir;
+                return new Error(
+                  `No supported framework was detected in ${dir}.\n` +
+                    `Because this directory isn't empty, a new app wasn't scaffolded, and no recognized ` +
+                    `framework (such as a package.json with Next.js) was found to install into.\n\n` +
+                    `Next steps:\n` +
+                    `  - New app: run \`workos install\` in an empty directory to scaffold Next.js + AuthKit.\n` +
+                    `  - Existing project: run from the directory that contains your package.json, or pass --install-dir <path>.`,
+                );
+              },
+            }),
             { type: 'emitStateExit', params: { state: 'preparing' } },
           ],
         },

--- a/src/lib/installer-core.ts
+++ b/src/lib/installer-core.ts
@@ -73,6 +73,17 @@ export const installerMachine = setup({
     emitScaffoldChecking: ({ context }) => {
       context.emitter.emit('scaffold:checking', {});
     },
+    // v1 scaffolding is Next.js-only (see scaffold.ts). If the user pre-selected a
+    // different integration, the scaffold can't honor it — say so once, before we
+    // prompt or auto-scaffold, rather than silently handing them a Next.js app.
+    emitScaffoldIntegrationNotice: ({ context }) => {
+      const requested = context.options.integration;
+      if (requested && requested !== 'nextjs' && requested !== 'next') {
+        context.emitter.emit('scaffold:notice', {
+          message: `Scaffolding currently supports Next.js only; ignoring --integration ${requested}.`,
+        });
+      }
+    },
     emitScaffoldPrompt: ({ context }) => {
       context.emitter.emit('scaffold:prompt', { packageManager: context.packageManager ?? 'npm' });
     },
@@ -485,12 +496,12 @@ export const installerMachine = setup({
                 // Headless or --scaffold: skip the prompt.
                 target: 'running',
                 guard: 'shouldAutoScaffold',
-                actions: ['assignWorkspaceResult'],
+                actions: ['assignWorkspaceResult', 'emitScaffoldIntegrationNotice'],
               },
               {
                 // Interactive empty dir: ask first.
                 target: 'prompting',
-                actions: ['assignWorkspaceResult'],
+                actions: ['assignWorkspaceResult', 'emitScaffoldIntegrationNotice'],
               },
             ],
             onError: {

--- a/src/lib/installer-core.ts
+++ b/src/lib/installer-core.ts
@@ -10,6 +10,7 @@ import type {
   DiscoveryResult,
   CredentialSource,
   BranchCheckOutput,
+  WorkspaceCheckOutput,
 } from './installer-core.types.js';
 import type { InstallerOptions } from '../utils/types.js';
 import type { DeviceAuthResult, DeviceAuthResponse } from './device-auth.js';
@@ -69,6 +70,34 @@ export const installerMachine = setup({
     emitGitCancelled: ({ context }) => {
       context.emitter.emit('git:dirty:cancelled', {});
     },
+    emitScaffoldChecking: ({ context }) => {
+      context.emitter.emit('scaffold:checking', {});
+    },
+    emitScaffoldPrompt: ({ context }) => {
+      context.emitter.emit('scaffold:prompt', { packageManager: context.packageManager ?? 'npm' });
+    },
+    emitScaffoldStart: ({ context }) => {
+      context.emitter.emit('scaffold:start', { packageManager: context.packageManager ?? 'npm' });
+    },
+    emitScaffoldComplete: ({ context }) => {
+      context.emitter.emit('scaffold:complete', {});
+    },
+    emitScaffoldFailed: ({ context }) => {
+      const message = context.error?.message ?? 'Scaffold failed';
+      context.emitter.emit('scaffold:failed', { error: message });
+    },
+    emitScaffoldSkipped: ({ context }) => {
+      context.emitter.emit('scaffold:skipped', {});
+    },
+    assignWorkspaceResult: assign({
+      scaffoldable: ({ event }) => (event as unknown as { output: WorkspaceCheckOutput }).output?.scaffoldable ?? false,
+      packageManager: ({ event }) =>
+        (event as unknown as { output: WorkspaceCheckOutput }).output?.packageManager ?? 'npm',
+      autoScaffold: ({ event }) => (event as unknown as { output: WorkspaceCheckOutput }).output?.autoScaffold ?? false,
+    }),
+    assignScaffolded: assign({
+      scaffolded: () => true,
+    }),
     emitBranchChecking: ({ context }) => {
       context.emitter.emit('branch:checking', {});
     },
@@ -294,11 +323,24 @@ export const installerMachine = setup({
     hasIntegration: ({ context }) => context.integration !== undefined,
     shouldSkipPostInstall: ({ context }) => context.options.noCommit === true,
     hasGhCli: () => hasGhCli(),
+    // Read from the actor's done event (output), not context: the
+    // assignWorkspaceResult action has not run yet when guards are evaluated.
+    notScaffoldable: ({ event }) => !(event as unknown as { output: WorkspaceCheckOutput }).output?.scaffoldable,
+    shouldAutoScaffold: ({ event }) => {
+      const output = (event as unknown as { output: WorkspaceCheckOutput }).output;
+      return !!output?.scaffoldable && !!output?.autoScaffold;
+    },
   },
 
   actors: {
     checkAuthentication: fromPromise<boolean, { options: InstallerOptions }>(async () => {
       throw new Error('checkAuthentication not implemented - provide via machine.provide()');
+    }),
+    checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async () => {
+      throw new Error('checkWorkspace not implemented - provide via machine.provide()');
+    }),
+    runScaffold: fromPromise<void, { context: InstallerMachineContext }>(async () => {
+      throw new Error('runScaffold not implemented - provide via machine.provide()');
     }),
     detectIntegration: fromPromise<DetectionOutput, { options: InstallerOptions }>(async () => {
       throw new Error('detectIntegration not implemented - provide via machine.provide()');
@@ -390,9 +432,9 @@ export const installerMachine = setup({
       on: {
         START: [
           {
-            target: 'preparing',
+            target: 'scaffold',
             guard: 'shouldSkipAuth',
-            actions: { type: 'emitStateEnter', params: { state: 'preparing' } },
+            actions: { type: 'emitStateEnter', params: { state: 'scaffold' } },
           },
           {
             target: 'authenticating',
@@ -409,17 +451,93 @@ export const installerMachine = setup({
         src: 'checkAuthentication',
         input: ({ context }) => ({ options: context.options }),
         onDone: {
-          target: 'preparing',
+          target: 'scaffold',
           actions: [
             'emitAuthSuccess',
             { type: 'emitStateExit', params: { state: 'authenticating' } },
-            { type: 'emitStateEnter', params: { state: 'preparing' } },
+            { type: 'emitStateEnter', params: { state: 'scaffold' } },
           ],
         },
         onError: {
           target: 'error',
           actions: ['assignError', 'emitAuthFailure', { type: 'emitStateExit', params: { state: 'authenticating' } }],
         },
+      },
+    },
+
+    scaffold: {
+      initial: 'checking',
+      states: {
+        checking: {
+          entry: ['emitScaffoldChecking'],
+          invoke: {
+            id: 'checkWorkspace',
+            src: 'checkWorkspace',
+            input: ({ context }) => ({ options: context.options }),
+            onDone: [
+              {
+                // Not an empty dir: fall through to today's behavior.
+                target: 'done',
+                guard: 'notScaffoldable',
+                actions: ['assignWorkspaceResult'],
+              },
+              {
+                // Headless or --scaffold: skip the prompt.
+                target: 'running',
+                guard: 'shouldAutoScaffold',
+                actions: ['assignWorkspaceResult'],
+              },
+              {
+                // Interactive empty dir: ask first.
+                target: 'prompting',
+                actions: ['assignWorkspaceResult'],
+              },
+            ],
+            onError: {
+              // Workspace check failure is non-fatal: proceed to preparing,
+              // which errors on no-integration exactly as before this feature.
+              target: 'done',
+            },
+          },
+        },
+        prompting: {
+          entry: ['emitScaffoldPrompt'],
+          on: {
+            SCAFFOLD_CONFIRMED: {
+              target: 'running',
+            },
+            SCAFFOLD_CANCELLED: {
+              target: '#installer.cancelled',
+              actions: ['emitScaffoldSkipped', { type: 'emitStateExit', params: { state: 'scaffold' } }],
+            },
+          },
+        },
+        running: {
+          entry: ['emitScaffoldStart'],
+          invoke: {
+            id: 'runScaffold',
+            src: 'runScaffold',
+            input: ({ context }) => ({ context }),
+            onDone: {
+              target: 'done',
+              actions: ['assignScaffolded', 'emitScaffoldComplete'],
+            },
+            onError: {
+              target: '#installer.error',
+              actions: ['assignError', 'emitScaffoldFailed', { type: 'emitStateExit', params: { state: 'scaffold' } }],
+            },
+          },
+        },
+        done: {
+          type: 'final',
+        },
+      },
+      onDone: {
+        target: 'preparing',
+        actions: [
+          { type: 'emitStateExit', params: { state: 'scaffold' } },
+          { type: 'emitStateEnter', params: { state: 'preparing' } },
+        ],
       },
     },
 

--- a/src/lib/installer-core.ts
+++ b/src/lib/installer-core.ts
@@ -73,17 +73,6 @@ export const installerMachine = setup({
     emitScaffoldChecking: ({ context }) => {
       context.emitter.emit('scaffold:checking', {});
     },
-    // v1 scaffolding is Next.js-only (see scaffold.ts). If the user pre-selected a
-    // different integration, the scaffold can't honor it — say so once, before we
-    // prompt or auto-scaffold, rather than silently handing them a Next.js app.
-    emitScaffoldIntegrationNotice: ({ context }) => {
-      const requested = context.options.integration;
-      if (requested && requested !== 'nextjs' && requested !== 'next') {
-        context.emitter.emit('scaffold:notice', {
-          message: `Scaffolding currently supports Next.js only; ignoring --integration ${requested}.`,
-        });
-      }
-    },
     emitScaffoldPrompt: ({ context }) => {
       context.emitter.emit('scaffold:prompt', { packageManager: context.packageManager ?? 'npm' });
     },
@@ -421,7 +410,8 @@ export const installerMachine = setup({
   context: ({ input }) => ({
     emitter: input.emitter,
     options: input.options,
-    integration: input.options.integration,
+    // Set by the detection actor; no pre-seeding (the --integration flag is gone).
+    integration: undefined,
     credentials:
       input.options.apiKey && input.options.clientId
         ? { apiKey: input.options.apiKey, clientId: input.options.clientId }
@@ -496,12 +486,12 @@ export const installerMachine = setup({
                 // Headless or --scaffold: skip the prompt.
                 target: 'running',
                 guard: 'shouldAutoScaffold',
-                actions: ['assignWorkspaceResult', 'emitScaffoldIntegrationNotice'],
+                actions: ['assignWorkspaceResult'],
               },
               {
                 // Interactive empty dir: ask first.
                 target: 'prompting',
-                actions: ['assignWorkspaceResult', 'emitScaffoldIntegrationNotice'],
+                actions: ['assignWorkspaceResult'],
               },
             ],
             onError: {

--- a/src/lib/installer-core.types.ts
+++ b/src/lib/installer-core.types.ts
@@ -1,6 +1,7 @@
 import type { InstallerEventEmitter } from './events.js';
 import type { InstallerOptions } from '../utils/types.js';
 import type { Integration } from './constants.js';
+import type { PackageManager } from './scaffold/scaffold.js';
 import type { DeviceAuthResponse } from './device-auth.js';
 import type { EnvFileInfo, DiscoveryResult } from './credential-discovery.js';
 
@@ -59,6 +60,14 @@ export interface InstallerMachineContext {
   prUrl?: string;
   /** Summary message from agent execution */
   agentSummary?: string;
+  /** Whether the install directory is empty and can be scaffolded into */
+  scaffoldable?: boolean;
+  /** Package manager resolved for the scaffolded app */
+  packageManager?: PackageManager;
+  /** Whether to scaffold without prompting (headless mode or --scaffold) */
+  autoScaffold?: boolean;
+  /** Whether create-next-app actually ran and succeeded (for telemetry) */
+  scaffolded?: boolean;
 }
 
 /**
@@ -78,6 +87,9 @@ export type InstallerMachineEvent =
   | { type: 'SKIP_AUTH' }
   | { type: 'GIT_CONFIRMED' }
   | { type: 'GIT_CANCELLED' }
+  // Scaffold events
+  | { type: 'SCAFFOLD_CONFIRMED' }
+  | { type: 'SCAFFOLD_CANCELLED' }
   | { type: 'CREDENTIALS_SUBMITTED'; apiKey: string; clientId: string }
   | { type: 'CANCEL' }
   // Credential discovery events
@@ -124,4 +136,16 @@ export interface AgentOutput {
 export interface BranchCheckOutput {
   branch: string | null;
   isProtected: boolean;
+}
+
+/**
+ * Output from the workspace check actor (scaffold gate).
+ */
+export interface WorkspaceCheckOutput {
+  /** Whether the install directory is empty enough to scaffold into */
+  scaffoldable: boolean;
+  /** Package manager resolved for the scaffolded app */
+  packageManager: PackageManager;
+  /** Whether to scaffold without prompting (headless or --scaffold) */
+  autoScaffold: boolean;
 }

--- a/src/lib/run-with-core.ts
+++ b/src/lib/run-with-core.ts
@@ -16,7 +16,9 @@ import type {
   GitCheckOutput,
   AgentOutput,
   BranchCheckOutput,
+  WorkspaceCheckOutput,
 } from './installer-core.types.js';
+import { isScaffoldableEmptyDir, resolvePackageManager, runCreateNextApp } from './scaffold/index.js';
 import type { Integration } from './constants.js';
 import { parseEnvFile } from '../utils/env-parser.js';
 import { enableDebugLogs, initLogFile, logInfo, logError } from '../utils/debug.js';
@@ -246,6 +248,26 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
         }
 
         return true;
+      }),
+
+      checkWorkspace: fromPromise<WorkspaceCheckOutput, { options: InstallerOptions }>(async ({ input }) => {
+        const scaffoldable = await isScaffoldableEmptyDir(input.options.installDir);
+        const packageManager = resolvePackageManager({
+          pm: input.options.pm,
+          userAgent: process.env.npm_config_user_agent,
+        });
+        // headlessMode is computed above; --scaffold opts in during interactive runs.
+        const autoScaffold = scaffoldable && (headlessMode || !!input.options.scaffold);
+        return { scaffoldable, packageManager, autoScaffold };
+      }),
+
+      runScaffold: fromPromise<void, { context: InstallerMachineContext }>(async ({ input }) => {
+        const { options: installerOptions, packageManager, emitter: ctxEmitter } = input.context;
+        await runCreateNextApp({
+          installDir: installerOptions.installDir,
+          packageManager: packageManager ?? 'npm',
+          emitter: ctxEmitter,
+        });
       }),
 
       detectIntegration: fromPromise<DetectionOutput, { options: InstallerOptions }>(async ({ input }) => {
@@ -568,9 +590,15 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
     // tag install metrics by integration). Known only after detection runs, so
     // it's read from the final machine snapshot here; absent if the session
     // aborted before detection.
-    const detectedIntegration = actor?.getSnapshot().context.integration;
+    const finalContext = actor?.getSnapshot().context;
+    const detectedIntegration = finalContext?.integration;
     if (detectedIntegration) {
       analytics.setTag('installer.integration', detectedIntegration);
+    }
+    // Record whether the empty-dir flow scaffolded a new app, so session.end
+    // carries it for adoption + scaffold-failure tracking.
+    if (finalContext?.scaffolded) {
+      analytics.setTag('scaffolded', true);
     }
     await analytics.shutdown(installerStatus);
     await adapter.stop();

--- a/src/lib/scaffold/index.ts
+++ b/src/lib/scaffold/index.ts
@@ -1,0 +1,9 @@
+export {
+  CREATE_NEXT_APP_VERSION,
+  SAFE_EMPTY_FILES,
+  buildCreateNextAppArgs,
+  isScaffoldableEmptyDir,
+  resolvePackageManager,
+  runCreateNextApp,
+  type PackageManager,
+} from './scaffold.js';

--- a/src/lib/scaffold/scaffold.spec.ts
+++ b/src/lib/scaffold/scaffold.spec.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock the spawn used by runCreateNextApp. Hoisted by vitest.
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+import { spawn } from 'node:child_process';
+
+import {
+  CREATE_NEXT_APP_VERSION,
+  SAFE_EMPTY_FILES,
+  buildCreateNextAppArgs,
+  isScaffoldableEmptyDir,
+  resolvePackageManager,
+  runCreateNextApp,
+  type PackageManager,
+} from './scaffold.js';
+import { InstallerEventEmitter } from '../events.js';
+
+describe('isScaffoldableEmptyDir', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'workos-scaffold-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, content = ''): void {
+    writeFileSync(join(dir, name), content);
+  }
+
+  it('returns true for a truly empty directory', async () => {
+    expect(await isScaffoldableEmptyDir(dir)).toBe(true);
+  });
+
+  it('returns true when only safe files are present (.git + .gitignore)', async () => {
+    mkdirSync(join(dir, '.git'));
+    write('.gitignore', 'node_modules');
+    write('LICENSE', 'MIT');
+    expect(await isScaffoldableEmptyDir(dir)).toBe(true);
+  });
+
+  it('returns false when a package.json is present', async () => {
+    write('package.json', '{}');
+    expect(await isScaffoldableEmptyDir(dir)).toBe(false);
+  });
+
+  it('returns false when an unrelated stray file is present', async () => {
+    mkdirSync(join(dir, '.git'));
+    write('notes.txt', 'hello');
+    expect(await isScaffoldableEmptyDir(dir)).toBe(false);
+  });
+
+  it('returns false for a non-JS manifest (go.mod)', async () => {
+    write('go.mod', 'module example.com/app');
+    expect(await isScaffoldableEmptyDir(dir)).toBe(false);
+  });
+
+  it('SAFE_EMPTY_FILES excludes README.md (not in create-next-app validFiles)', () => {
+    expect(SAFE_EMPTY_FILES.has('README.md')).toBe(false);
+    expect(SAFE_EMPTY_FILES.has('.vscode')).toBe(false);
+  });
+});
+
+describe('resolvePackageManager', () => {
+  it('parses pnpm from the user agent', () => {
+    expect(resolvePackageManager({ userAgent: 'pnpm/8.6.0 npm/? node/v20.0.0 darwin arm64' })).toBe('pnpm');
+  });
+
+  it('parses bun from the user agent', () => {
+    expect(resolvePackageManager({ userAgent: 'bun/1.1.0 npm/? node/v20' })).toBe('bun');
+  });
+
+  it('parses yarn from the user agent', () => {
+    expect(resolvePackageManager({ userAgent: 'yarn/4.0.0 npm/? node/v20' })).toBe('yarn');
+  });
+
+  it('falls back to npm when the user agent is absent', () => {
+    expect(resolvePackageManager({})).toBe('npm');
+  });
+
+  it('falls back to npm for an unrecognized user agent', () => {
+    expect(resolvePackageManager({ userAgent: 'cnpm/1.0.0 node/v20' })).toBe('npm');
+  });
+
+  it('lets a valid --pm override beat the user agent', () => {
+    expect(resolvePackageManager({ pm: 'pnpm', userAgent: 'npm/10.0.0 node/v20' })).toBe('pnpm');
+  });
+
+  it('ignores an invalid --pm and falls through to the user agent', () => {
+    expect(resolvePackageManager({ pm: 'cargo', userAgent: 'pnpm/8 npm/? node/v20' })).toBe('pnpm');
+  });
+
+  it('ignores an invalid --pm and falls back to npm with no user agent', () => {
+    expect(resolvePackageManager({ pm: 'cargo' })).toBe('npm');
+  });
+});
+
+describe('buildCreateNextAppArgs', () => {
+  it('produces the exact pinned arg array for pnpm', () => {
+    expect(buildCreateNextAppArgs('pnpm')).toEqual([
+      '.',
+      '--ts',
+      '--app',
+      '--eslint',
+      '--tailwind',
+      '--src-dir',
+      '--import-alias',
+      '@/*',
+      '--use-pnpm',
+      '--yes',
+    ]);
+  });
+
+  it('ends with --use-<pm> for each package manager', () => {
+    const managers: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+    for (const pm of managers) {
+      const args = buildCreateNextAppArgs(pm);
+      expect(args.at(-1)).toBe('--yes');
+      expect(args).toContain(`--use-${pm}`);
+      // App shape stays constant regardless of PM.
+      expect(args).toEqual(expect.arrayContaining(['--ts', '--app', '--tailwind', '--src-dir']));
+    }
+  });
+
+  it('does not pass a turbopack flag (relies on --yes defaults)', () => {
+    const args = buildCreateNextAppArgs('npm');
+    expect(args).not.toContain('--turbopack');
+    expect(args).not.toContain('--no-turbopack');
+  });
+});
+
+describe('runCreateNextApp', () => {
+  function makeFakeChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    return child;
+  }
+
+  beforeEach(() => {
+    (spawn as unknown as Mock).mockReset();
+  });
+
+  it('spawns npx with the pinned create-next-app version and cwd, streaming progress', async () => {
+    const child = makeFakeChild();
+    (spawn as unknown as Mock).mockReturnValue(child);
+
+    const emitter = new InstallerEventEmitter();
+    const progress: string[] = [];
+    emitter.on('scaffold:progress', (p) => progress.push(p.text));
+
+    const promise = runCreateNextApp({ installDir: '/tmp/wos-empty', packageManager: 'pnpm', emitter });
+
+    child.stdout.emit('data', Buffer.from('Creating a new Next.js app...'));
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(progress.join('')).toContain('Creating a new Next.js app');
+    expect(spawn).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining([`create-next-app@${CREATE_NEXT_APP_VERSION}`, '--use-pnpm']),
+      expect.objectContaining({ cwd: '/tmp/wos-empty' }),
+    );
+  });
+
+  it('rejects when create-next-app exits non-zero, preserving stderr', async () => {
+    const child = makeFakeChild();
+    (spawn as unknown as Mock).mockReturnValue(child);
+
+    const emitter = new InstallerEventEmitter();
+    const promise = runCreateNextApp({ installDir: '/tmp/wos-empty', packageManager: 'npm', emitter });
+
+    child.stderr.emit('data', Buffer.from('network error'));
+    child.emit('close', 1);
+
+    await expect(promise).rejects.toThrow(/exited with code 1.*network error/s);
+  });
+
+  it('rejects on spawn error', async () => {
+    const child = makeFakeChild();
+    (spawn as unknown as Mock).mockReturnValue(child);
+
+    const emitter = new InstallerEventEmitter();
+    const promise = runCreateNextApp({ installDir: '/tmp/wos-empty', packageManager: 'npm', emitter });
+
+    child.emit('error', new Error('spawn npx ENOENT'));
+
+    await expect(promise).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/src/lib/scaffold/scaffold.spec.ts
+++ b/src/lib/scaffold/scaffold.spec.ts
@@ -237,4 +237,16 @@ describe('runCreateNextApp', () => {
     // 2000-char stderr cap + the "create-next-app exited with code 1: " prefix.
     expect(err.message.length).toBeLessThan(2100);
   });
+
+  it('reports the signal when create-next-app is killed (null exit code)', async () => {
+    const child = makeFakeChild();
+    (spawn as unknown as Mock).mockReturnValue(child);
+
+    const emitter = new InstallerEventEmitter();
+    const promise = runCreateNextApp({ installDir: '/tmp/wos-empty', packageManager: 'npm', emitter });
+
+    child.emit('close', null, 'SIGTERM');
+
+    await expect(promise).rejects.toThrow(/killed by signal SIGTERM/);
+  });
 });

--- a/src/lib/scaffold/scaffold.spec.ts
+++ b/src/lib/scaffold/scaffold.spec.ts
@@ -147,7 +147,7 @@ describe('runCreateNextApp', () => {
     (spawn as unknown as Mock).mockReset();
   });
 
-  it('spawns npx with the pinned create-next-app version and cwd, streaming progress', async () => {
+  it('runs create-next-app via the package manager runner, streaming progress', async () => {
     const child = makeFakeChild();
     (spawn as unknown as Mock).mockReturnValue(child);
 
@@ -163,10 +163,38 @@ describe('runCreateNextApp', () => {
     await expect(promise).resolves.toBeUndefined();
     expect(progress.join('')).toContain('Creating a new Next.js app');
     expect(spawn).toHaveBeenCalledWith(
-      'npx',
-      expect.arrayContaining([`create-next-app@${CREATE_NEXT_APP_VERSION}`, '--use-pnpm']),
+      'pnpm',
+      expect.arrayContaining(['dlx', `create-next-app@${CREATE_NEXT_APP_VERSION}`, '--use-pnpm']),
       expect.objectContaining({ cwd: '/tmp/wos-empty' }),
     );
+  });
+
+  it('uses each package manager its own runner (npx / pnpm dlx / yarn dlx / bunx)', async () => {
+    const cases: Array<[PackageManager, string, string[]]> = [
+      ['npm', 'npx', ['--yes', `create-next-app@${CREATE_NEXT_APP_VERSION}`]],
+      ['pnpm', 'pnpm', ['dlx', `create-next-app@${CREATE_NEXT_APP_VERSION}`]],
+      ['yarn', 'yarn', ['dlx', `create-next-app@${CREATE_NEXT_APP_VERSION}`]],
+      ['bun', 'bunx', [`create-next-app@${CREATE_NEXT_APP_VERSION}`]],
+    ];
+
+    for (const [pm, bin, leadingArgs] of cases) {
+      (spawn as unknown as Mock).mockReset();
+      const child = makeFakeChild();
+      (spawn as unknown as Mock).mockReturnValue(child);
+
+      const promise = runCreateNextApp({
+        installDir: '/tmp/x',
+        packageManager: pm,
+        emitter: new InstallerEventEmitter(),
+      });
+      child.emit('close', 0);
+      await expect(promise).resolves.toBeUndefined();
+
+      const [calledBin, calledArgs] = (spawn as unknown as Mock).mock.calls[0] as [string, string[]];
+      expect(calledBin).toBe(bin);
+      expect(calledArgs.slice(0, leadingArgs.length)).toEqual(leadingArgs);
+      expect(calledArgs).toContain(`--use-${pm}`);
+    }
   });
 
   it('rejects when create-next-app exits non-zero, preserving stderr', async () => {
@@ -192,5 +220,21 @@ describe('runCreateNextApp', () => {
     child.emit('error', new Error('spawn npx ENOENT'));
 
     await expect(promise).rejects.toThrow(/ENOENT/);
+  });
+
+  it('caps stderr in the rejection message', async () => {
+    const child = makeFakeChild();
+    (spawn as unknown as Mock).mockReturnValue(child);
+
+    const emitter = new InstallerEventEmitter();
+    const promise = runCreateNextApp({ installDir: '/tmp/wos-empty', packageManager: 'npm', emitter });
+
+    child.stderr.emit('data', Buffer.from('e'.repeat(5000)));
+    child.emit('close', 1);
+
+    const err = (await promise.catch((e: unknown) => e)) as Error;
+    expect(err).toBeInstanceOf(Error);
+    // 2000-char stderr cap + the "create-next-app exited with code 1: " prefix.
+    expect(err.message.length).toBeLessThan(2100);
   });
 });

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -93,10 +93,8 @@ export function resolvePackageManager(opts: { pm?: string; userAgent?: string })
  * The pinned `create-next-app` flag set. Kept pure so a unit test can assert the
  * exact array — flag drift across a pinned major is the primary failure mode.
  *
- * v1 scaffolds Next.js only. `--integration <other>` cannot be honored here yet;
- * the state machine emits a `scaffold:notice` to say so. Multi-framework
- * scaffolding (e.g. `--integration react` -> a Vite React app via its own
- * `create-*` tool) is a tracked follow-up, not implemented.
+ * v1 scaffolds Next.js only. Multi-framework scaffolding (e.g. a Vite React app
+ * via its own `create-*` tool) is a tracked follow-up, not implemented.
  *
  * App Router + TypeScript + ESLint + Tailwind + `src/` + `@/*` alias, installed
  * with the resolved package manager. `--yes` accepts all remaining defaults

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -1,0 +1,148 @@
+import { spawn } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import { SPAWN_OPTS } from '../../utils/platform.js';
+import type { InstallerEventEmitter } from '../events.js';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/**
+ * The `create-next-app` major we pin to. Matches `authkit-nextjs/examples/next`
+ * (Next 16). A major float (`@16`) keeps the pinned flag set stable while still
+ * receiving patch/minor updates. Re-pin when AuthKit bumps its supported Next major.
+ * `@latest` is intentionally avoided — it would reintroduce the flag-drift
+ * non-determinism this deterministic step exists to prevent.
+ */
+export const CREATE_NEXT_APP_VERSION = '16';
+
+const VALID_PACKAGE_MANAGERS: ReadonlySet<string> = new Set<PackageManager>(['npm', 'pnpm', 'yarn', 'bun']);
+
+/**
+ * Files that may be present in a directory we still consider "scaffoldable empty".
+ *
+ * INVARIANT: this MUST stay a subset of create-next-app's own `validFiles`
+ * (verified against the v{@link CREATE_NEXT_APP_VERSION} tag). If ours is
+ * stricter, we simply scaffold less often (safe). If ours were looser,
+ * create-next-app would accept our offer and then refuse mid-run.
+ *
+ * We omit `docs` and `mkdocs.yml` from the upstream list on purpose — their
+ * presence usually signals real project content, so we err toward NOT scaffolding.
+ * We also omit `README.md`/`.vscode`: they are NOT in create-next-app's list, so a
+ * directory containing them is left to the normal (non-scaffold) install path.
+ */
+export const SAFE_EMPTY_FILES: ReadonlySet<string> = new Set([
+  '.DS_Store',
+  '.git',
+  '.gitattributes',
+  '.gitignore',
+  '.gitlab-ci.yml',
+  '.hg',
+  '.hgcheck',
+  '.hgignore',
+  '.idea',
+  '.npmignore',
+  '.travis.yml',
+  'LICENSE',
+  'Thumbs.db',
+  'npm-debug.log',
+  'yarn-debug.log',
+  'yarn-error.log',
+  'yarnrc.yml',
+  '.yarn',
+]);
+
+/**
+ * True iff `dir` is empty or contains only {@link SAFE_EMPTY_FILES} entries.
+ *
+ * Because no project manifest (`package.json`, `go.mod`, `Gemfile`, etc.) appears
+ * in {@link SAFE_EMPTY_FILES}, the presence of any manifest makes this return
+ * false — i.e. an existing project always takes the normal install path.
+ */
+export async function isScaffoldableEmptyDir(dir: string): Promise<boolean> {
+  const entries = await readdir(dir);
+  return entries.every((entry) => SAFE_EMPTY_FILES.has(entry));
+}
+
+/**
+ * Resolve the package manager for the scaffolded app.
+ *
+ * Precedence: validated `--pm` override > `npm_config_user_agent` parse > `npm`.
+ * An empty directory has no lockfile, so lockfile-based detection does not apply;
+ * we read the runner from the user agent instead (e.g. `pnpm dlx` → `pnpm`).
+ */
+export function resolvePackageManager(opts: { pm?: string; userAgent?: string }): PackageManager {
+  const { pm, userAgent } = opts;
+
+  // `--pm` is validated by yargs `choices` upstream; guard again defensively and
+  // fall through on anything unexpected rather than throwing here.
+  if (pm && VALID_PACKAGE_MANAGERS.has(pm)) {
+    return pm as PackageManager;
+  }
+
+  if (userAgent) {
+    // e.g. "pnpm/8.6.0 npm/? node/v20.0.0 darwin arm64" → "pnpm"
+    const name = userAgent.split(/\s+/)[0]?.split('/')[0];
+    if (name && VALID_PACKAGE_MANAGERS.has(name)) {
+      return name as PackageManager;
+    }
+  }
+
+  return 'npm';
+}
+
+/**
+ * The pinned `create-next-app` flag set. Kept pure so a unit test can assert the
+ * exact array — flag drift across a pinned major is the primary failure mode.
+ *
+ * App Router + TypeScript + ESLint + Tailwind + `src/` + `@/*` alias, installed
+ * with the resolved package manager. `--yes` accepts all remaining defaults
+ * (including the major's Turbopack default) and prevents interactive hangs.
+ */
+export function buildCreateNextAppArgs(pm: PackageManager): string[] {
+  return ['.', '--ts', '--app', '--eslint', '--tailwind', '--src-dir', '--import-alias', '@/*', `--use-${pm}`, '--yes'];
+}
+
+/**
+ * Spawn `npx create-next-app@<pinned> .` in `installDir`, streaming output as
+ * `scaffold:progress` events. Resolves on exit 0; rejects on non-zero exit or
+ * spawn error so the state machine can route to its error state.
+ */
+export function runCreateNextApp(opts: {
+  installDir: string;
+  packageManager: PackageManager;
+  emitter: InstallerEventEmitter;
+}): Promise<void> {
+  const { installDir, packageManager, emitter } = opts;
+  const args = [`--yes`, `create-next-app@${CREATE_NEXT_APP_VERSION}`, ...buildCreateNextAppArgs(packageManager)];
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn('npx', args, {
+      cwd: installDir,
+      env: process.env,
+      ...SPAWN_OPTS,
+    });
+
+    let stderr = '';
+
+    const stream = (data: Buffer): void => {
+      emitter.emit('scaffold:progress', { text: data.toString() });
+    };
+
+    child.stdout?.on('data', stream);
+    child.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+      stream(data);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`create-next-app exited with code ${code ?? 1}${stderr ? `: ${stderr.trim()}` : ''}`));
+      }
+    });
+
+    child.on('error', (err) => {
+      reject(err);
+    });
+  });
+}

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -93,6 +93,11 @@ export function resolvePackageManager(opts: { pm?: string; userAgent?: string })
  * The pinned `create-next-app` flag set. Kept pure so a unit test can assert the
  * exact array — flag drift across a pinned major is the primary failure mode.
  *
+ * v1 scaffolds Next.js only. `--integration <other>` cannot be honored here yet;
+ * the state machine emits a `scaffold:notice` to say so. Multi-framework
+ * scaffolding (e.g. `--integration react` -> a Vite React app via its own
+ * `create-*` tool) is a tracked follow-up, not implemented.
+ *
  * App Router + TypeScript + ESLint + Tailwind + `src/` + `@/*` alias, installed
  * with the resolved package manager. `--yes` accepts all remaining defaults
  * (including the major's Turbopack default) and prevents interactive hangs.

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -105,9 +105,23 @@ export function buildCreateNextAppArgs(pm: PackageManager): string[] {
 }
 
 /**
- * Spawn `npx create-next-app@<pinned> .` in `installDir`, streaming output as
- * `scaffold:progress` events. Resolves on exit 0; rejects on non-zero exit or
- * spawn error so the state machine can route to its error state.
+ * Each package manager's own package runner. Running create-next-app through the
+ * resolved PM's runner (instead of always `npx`) means we don't require npm/npx
+ * to be on PATH — e.g. a bun-only machine has no `npx`. `yarn dlx` assumes
+ * Yarn >= 2 (Berry); a Yarn 1 user would need `--pm npm`.
+ */
+const PM_RUNNER: Record<PackageManager, { bin: string; args: string[] }> = {
+  npm: { bin: 'npx', args: ['--yes'] },
+  pnpm: { bin: 'pnpm', args: ['dlx'] },
+  yarn: { bin: 'yarn', args: ['dlx'] },
+  bun: { bin: 'bunx', args: [] },
+};
+
+/**
+ * Spawn `create-next-app@<pinned> .` in `installDir` via the resolved package
+ * manager's runner, streaming output as `scaffold:progress` events. Resolves on
+ * exit 0; rejects on non-zero exit or spawn error so the state machine can route
+ * to its error state.
  */
 export function runCreateNextApp(opts: {
   installDir: string;
@@ -115,10 +129,11 @@ export function runCreateNextApp(opts: {
   emitter: InstallerEventEmitter;
 }): Promise<void> {
   const { installDir, packageManager, emitter } = opts;
-  const args = [`--yes`, `create-next-app@${CREATE_NEXT_APP_VERSION}`, ...buildCreateNextAppArgs(packageManager)];
+  const runner = PM_RUNNER[packageManager];
+  const args = [...runner.args, `create-next-app@${CREATE_NEXT_APP_VERSION}`, ...buildCreateNextAppArgs(packageManager)];
 
   return new Promise<void>((resolve, reject) => {
-    const child = spawn('npx', args, {
+    const child = spawn(runner.bin, args, {
       cwd: installDir,
       env: process.env,
       ...SPAWN_OPTS,
@@ -140,7 +155,9 @@ export function runCreateNextApp(opts: {
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`create-next-app exited with code ${code ?? 1}${stderr ? `: ${stderr.trim()}` : ''}`));
+        // Cap stderr so a long npm/dependency-resolution trace doesn't bloat the error.
+        const detail = stderr ? `: ${stderr.trim().slice(0, 2000)}` : '';
+        reject(new Error(`create-next-app exited with code ${code ?? 1}${detail}`));
       }
     });
 

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -147,17 +147,23 @@ export function runCreateNextApp(opts: {
 
     child.stdout?.on('data', stream);
     child.stderr?.on('data', (data: Buffer) => {
-      stderr += data.toString();
+      // Bound the buffer at collection time so a pathological failure (e.g. a full
+      // npm resolution trace) can't accumulate hundreds of KB. Progress still streams.
+      if (stderr.length < 2000) {
+        stderr += data.toString();
+      }
       stream(data);
     });
 
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
       if (code === 0) {
         resolve();
       } else {
-        // Cap stderr so a long npm/dependency-resolution trace doesn't bloat the error.
         const detail = stderr ? `: ${stderr.trim().slice(0, 2000)}` : '';
-        reject(new Error(`create-next-app exited with code ${code ?? 1}${detail}`));
+        // code is null when the process was killed by a signal (e.g. SIGTERM from a
+        // timeout layer); surface that instead of masking it as "exited with code 1".
+        const exitInfo = code !== null ? `exited with code ${code}` : `was killed by signal ${signal ?? 'unknown'}`;
+        reject(new Error(`create-next-app ${exitInfo}${detail}`));
       }
     });
 

--- a/src/lib/scaffold/scaffold.ts
+++ b/src/lib/scaffold/scaffold.ts
@@ -130,7 +130,11 @@ export function runCreateNextApp(opts: {
 }): Promise<void> {
   const { installDir, packageManager, emitter } = opts;
   const runner = PM_RUNNER[packageManager];
-  const args = [...runner.args, `create-next-app@${CREATE_NEXT_APP_VERSION}`, ...buildCreateNextAppArgs(packageManager)];
+  const args = [
+    ...runner.args,
+    `create-next-app@${CREATE_NEXT_APP_VERSION}`,
+    ...buildCreateNextAppArgs(packageManager),
+  ];
 
   return new Promise<void>((resolve, reject) => {
     const child = spawn(runner.bin, args, {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,6 @@
 import { readEnvironment } from './utils/environment.js';
 import { runWithCore } from './lib/run-with-core.js';
 import type { InstallerOptions } from './utils/types.js';
-import type { Integration } from './lib/constants.js';
 import { createInstallerEventEmitter } from './lib/events.js';
 import path from 'path';
 import { EventEmitter } from 'events';
@@ -9,7 +8,6 @@ import { EventEmitter } from 'events';
 EventEmitter.defaultMaxListeners = 50;
 
 export type InstallerArgs = {
-  integration?: Integration;
   debug?: boolean;
   forceInstall?: boolean;
   installDir?: string;
@@ -67,7 +65,6 @@ function buildOptions(argv: InstallerArgs): InstallerOptions {
     homepageUrl: merged.homepageUrl,
     redirectUri: merged.redirectUri,
     dashboard: merged.dashboard ?? false,
-    integration: merged.integration,
     inspect: merged.inspect ?? false,
     noValidate: merged.noValidate ?? merged.validate === false,
     noCommit: merged.noCommit ?? merged.commit === false,

--- a/src/run.ts
+++ b/src/run.ts
@@ -33,6 +33,8 @@ export type InstallerArgs = {
   noGitCheck?: boolean;
   gitCheck?: boolean;
   direct?: boolean;
+  scaffold?: boolean;
+  pm?: string;
 };
 
 /**
@@ -73,6 +75,8 @@ function buildOptions(argv: InstallerArgs): InstallerOptions {
     createPr: merged.createPr ?? false,
     noGitCheck: merged.noGitCheck ?? merged.gitCheck === false,
     direct: merged.direct ?? false,
+    scaffold: merged.scaffold ?? false,
+    pm: merged.pm,
     emitter: createInstallerEventEmitter(), // Will be replaced in runWithCore
   };
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -67,11 +67,6 @@ export type InstallerOptions = {
   emitter?: import('../lib/events.js').InstallerEventEmitter;
 
   /**
-   * Pre-selected framework integration (bypasses detection)
-   */
-  integration?: import('../lib/constants.js').Integration;
-
-  /**
    * Enable XState inspector - opens browser to visualize state machine live
    */
   inspect?: boolean;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -113,6 +113,18 @@ export type InstallerOptions = {
    * Default: 2. Set to 0 to disable retries entirely.
    */
   maxRetries?: number;
+
+  /**
+   * Scaffold a new Next.js app when run in an empty directory.
+   * Auto-enabled in headless mode; opt-in via --scaffold in interactive mode.
+   */
+  scaffold?: boolean;
+
+  /**
+   * Package manager for the scaffolded app (npm/pnpm/yarn/bun).
+   * Overrides detection from npm_config_user_agent.
+   */
+  pm?: string;
 };
 
 export interface Feature {


### PR DESCRIPTION
## What & why

Running `workos install` in an empty directory was a dead end: detection found no framework and the state machine errored at the `hasIntegration` guard. This adds a **delegate-don't-template** scaffold path — on an empty dir the CLI scaffolds a blank Next.js app with `create-next-app`, then the **existing** install pipeline detects and wires AuthKit, unchanged.

## How

- New compound `scaffold` XState state before `preparing` (`checking → prompting → running → done`), mirroring the existing `gitCheck`/`branchCheck` sub-machines. Both transitions that fed `preparing` now route through `scaffold` first.
- New `src/lib/scaffold` module: `isScaffoldableEmptyDir`, `resolvePackageManager`, `buildCreateNextAppArgs`, `runCreateNextApp`. Pinned `create-next-app@16` (major float), `--yes` defaults, spawned via `child_process`. **The agent Bash allowlist is untouched** — the scaffold never goes through the LLM.
- `scaffold:*` event family + wiring across all three adapters: CLI confirm (default yes) + a "next steps" hint, headless NDJSON with `scaffolded: true`, dashboard auto-proceed.
- `--scaffold` and `--pm` flags; package manager resolved from `npm_config_user_agent` (npm fallback).
- `scaffolded` recorded as a session telemetry tag.

## Empty-dir gate

Scaffolds only when **every** entry in the dir is in `SAFE_EMPTY_FILES` (a verified subset of create-next-app v16's `validFiles`): empty, or only VCS/editor/cruft metadata (`.git`, `.gitignore`, `LICENSE`, `.idea`, …). **Any project file — including `README.md` or `package.json` — opts the directory out** and it's treated as an existing project. Interactive = single confirm; headless / `--scaffold` = auto.

> Note: this excludes `README.md`/`.vscode` from the original spec's success criterion, deliberately, because they aren't in create-next-app's `validFiles` — including them would trip the "offer then create-next-app refuses" failure mode.

## Also in this PR

- **fix:** the empty-dir error is now actionable (names the directory, points to the empty-dir-scaffold vs existing-project paths) instead of the bare "Could not detect framework integration".
- **refactor:** removed the inert `--integration` flag. It was read in only two places and was unconditionally overwritten by detection before it could affect anything — vestigial surface that predated the XState detection step. Detection still selects the integration; removal is non-breaking (the install command is non-strict, so a leftover `--integration` is ignored). True multi-framework scaffolding is the future home for a flag like this.
- **docs:** README Installer Options + a Features bullet + an empty-dir behavior note + a greenfield example.

## Known follow-ups (not in this PR)

- Greenfield-with-`README.md` doesn't scaffold (by the gate above). If that's an important entry point, it needs a relocate-then-scaffold follow-up.
- True multi-framework scaffolding (e.g. a React/Vite app via its own `create-*` tool), at which point a framework-selection flag becomes meaningful again.
- Manual e2e still owed (real `create-next-app` run, `pnpm dlx` PM resolution, headless `scaffolded: true`).

## Validation

`pnpm typecheck` ✓ · `pnpm lint` ✓ (0/0) · `pnpm test` ✓ (2079) · `pnpm build` ✓.