### PR TITLE
fix: unblock agent/CI non-interactive CLI paths

### DIFF
--- a/src/bin-default-command.integration.spec.ts
+++ b/src/bin-default-command.integration.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Integration test for the fixed `$0` default-command output.
+ *
+ * bin.ts runs runCli() at import and exposes no seams, so the only honest way
+ * to prove the friction fix is to drive the real CLI as a subprocess and read
+ * its streams. Pre-fix, a bare non-TTY invocation ran `yargs(rawArgs).showHelp()`
+ * on a FRESH yargs instance (zero commands registered), emitting a degenerate
+ * two-line `--help`/`--version` block to stderr and leaving stdout empty — a
+ * piped agent/CI consumer got nothing and never discovered `install`.
+ *
+ * We use a LOCAL spawn helper (not the shared one in
+ * bin-command-telemetry.integration.spec.ts) because that one hardcodes
+ * WORKOS_MODE=agent, which the CI and human-force-TTY cases must omit. The env
+ * is built clean (spawnSync replaces, not merges) so host agent/CI markers are
+ * absent unless a case adds them.
+ */
+const binPath = fileURLToPath(new URL('./bin.ts', import.meta.url));
+const forceInsecureStorageImport = new URL('./test/force-insecure-storage.ts', import.meta.url).href;
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+let sandboxTmp: string;
+
+beforeEach(() => {
+  sandboxTmp = mkdtempSync(join(tmpdir(), 'wos-cli-default-it-'));
+});
+
+afterEach(() => {
+  rmSync(sandboxTmp, { recursive: true, force: true });
+});
+
+function runCli(args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    HOME: sandboxTmp,
+    USERPROFILE: sandboxTmp,
+    TMPDIR: sandboxTmp,
+    TMP: sandboxTmp,
+    TEMP: sandboxTmp,
+    // Keep machine streams clean: no telemetry, no update check network calls.
+    WORKOS_TELEMETRY: 'false',
+    // Unroutable API base (defense-in-depth; the $0 path never hits the network).
+    WORKOS_API_URL: 'http://127.0.0.1:59999',
+    // Per-case env last. Agent/CI markers are absent unless a case adds one.
+    ...envOverrides,
+  };
+
+  return spawnSync(process.execPath, ['--import', 'tsx', '--import', forceInsecureStorageImport, binPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    env,
+  });
+}
+
+describe('bin $0 default command (non-TTY)', () => {
+  it('agent mode emits the full machine-readable command tree on stdout', () => {
+    const result = runCli([], { WORKOS_MODE: 'agent' });
+
+    expect(result.status).toBe(0);
+
+    const tree = JSON.parse(result.stdout.trim());
+    expect(tree.name).toBe('workos');
+    expect(tree.version).toBeTruthy();
+
+    const names = tree.commands.map((c: { name: string }) => c.name);
+    expect(names).toEqual(expect.arrayContaining(['install', 'auth login', 'organization', 'doctor']));
+    // The installer must be discoverable — this is the friction being fixed.
+    expect(tree.commands.some((c: { name: string }) => c.name === 'install')).toBe(true);
+
+    // Regression guard: never emit the degenerate fresh-yargs help block.
+    expect(result.stderr).not.toContain('Show version number');
+  }, 20_000);
+
+  it('CI mode (CI=1, no WORKOS_MODE) emits the command tree on stdout', () => {
+    const result = runCli([], { CI: '1' });
+
+    expect(result.status).toBe(0);
+
+    const tree = JSON.parse(result.stdout.trim());
+    expect(tree.name).toBe('workos');
+    expect(tree.version).toBeTruthy();
+
+    const names = tree.commands.map((c: { name: string }) => c.name);
+    expect(names).toEqual(expect.arrayContaining(['install', 'auth login', 'organization', 'doctor']));
+    expect(result.stderr).not.toContain('Show version number');
+  }, 20_000);
+
+  it('human non-TTY edge (WORKOS_FORCE_TTY=1) shows the configured help, not JSON', () => {
+    // WORKOS_MODE omitted entirely (never set to '' — that throws InvalidInteractionModeError).
+    const result = runCli([], { WORKOS_FORCE_TTY: '1' });
+
+    expect(result.status).toBe(0);
+
+    const combined = `${result.stdout}\n${result.stderr}`;
+    // parser.showHelp() (not the fresh-yargs block) lists the full command set.
+    expect(combined).toMatch(/install/);
+    expect(combined).toMatch(/organization/);
+    expect(combined).toMatch(/auth/);
+  }, 20_000);
+
+  it('--help --json still returns the command tree (regression for the intercept)', () => {
+    const result = runCli(['--help', '--json'], { WORKOS_MODE: 'agent' });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(Array.isArray(parsed.commands)).toBe(true);
+    expect(parsed.commands.length).toBeGreaterThan(0);
+  }, 20_000);
+});

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -241,6 +241,11 @@ const installerOptions = {
     choices: ['npm', 'pnpm', 'yarn', 'bun'] as const,
     type: 'string' as const,
   },
+  router: {
+    choices: ['app', 'pages'] as const,
+    describe: 'Next.js router to target when detection is ambiguous (app or pages)',
+    type: 'string' as const,
+  },
 };
 
 // Check for updates (blocks up to 500ms, skip in JSON/non-human modes to keep machine streams clean)
@@ -2677,9 +2682,15 @@ async function runCli(): Promise<void> {
       'WorkOS AuthKit CLI',
       (yargs) => yargs.options(insecureStorageOption),
       async (argv) => {
-        // Non-human modes: show help instead of prompting
+        // Non-human modes: emit machine-readable command tree (JSON) or the
+        // fully-configured parser help (human non-TTY edge) instead of prompting.
         if (!isPromptAllowed()) {
-          yargs(rawArgs).showHelp();
+          if (isJsonMode()) {
+            const { buildCommandTree } = await import('./utils/help-json.js');
+            outputJson(buildCommandTree());
+          } else {
+            parser.showHelp();
+          }
           return;
         }
 

--- a/src/commands/install.spec.ts
+++ b/src/commands/install.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('../run.js', () => ({
   runInstaller: vi.fn(),
@@ -31,14 +31,19 @@ const { runInstaller } = await import('../run.js');
 const { autoInstallSkills } = await import('./install-skill.js');
 const { maybeOfferMcpInstall } = await import('../lib/mcp-notice.js');
 const clack = (await import('../utils/clack.js')).default;
-const { isJsonMode } = await import('../utils/output.js');
+const { isJsonMode, exitWithError } = await import('../utils/output.js');
 const { CliExit } = await import('../utils/cli-exit.js');
+const { setInteractionMode, resetInteractionModeForTests } = await import('../utils/interaction-mode.js');
 
 const { handleInstall } = await import('./install.js');
 
 describe('handleInstall', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetInteractionModeForTests();
   });
 
   it('calls autoInstallSkills after successful install', async () => {
@@ -125,5 +130,44 @@ describe('handleInstall', () => {
 
     expect(runInstaller).toHaveBeenCalledOnce();
     expect(autoInstallSkills).toHaveBeenCalledOnce();
+  });
+
+  describe('CI-mode required-arg validation', () => {
+    it('WORKOS_MODE=ci requires --api-key (validation triggered without the --ci flag)', async () => {
+      vi.mocked(runInstaller).mockResolvedValue(undefined as any);
+      vi.mocked(autoInstallSkills).mockResolvedValue(null);
+      setInteractionMode({ mode: 'ci', source: 'env' });
+
+      await handleInstall({ _: ['install'], $0: 'workos' } as any);
+
+      expect(exitWithError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'missing_args', message: expect.stringContaining('--api-key') }),
+      );
+    });
+
+    it('WORKOS_MODE=ci with all required args does not error', async () => {
+      vi.mocked(runInstaller).mockResolvedValue(undefined as any);
+      vi.mocked(autoInstallSkills).mockResolvedValue(null);
+      setInteractionMode({ mode: 'ci', source: 'env' });
+
+      await handleInstall({
+        _: ['install'],
+        $0: 'workos',
+        apiKey: 'sk_test',
+        clientId: 'client_x',
+        installDir: '/tmp/x',
+      } as any);
+
+      expect(exitWithError).not.toHaveBeenCalled();
+    });
+
+    it('default (human) mode does not trigger CI validation', async () => {
+      vi.mocked(runInstaller).mockResolvedValue(undefined as any);
+      vi.mocked(autoInstallSkills).mockResolvedValue(null);
+
+      await handleInstall({ _: ['install'], $0: 'workos' } as any);
+
+      expect(exitWithError).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -3,6 +3,7 @@ import type { InstallerArgs } from '../run.js';
 import clack from '../utils/clack.js';
 import { exitWithError, isJsonMode } from '../utils/output.js';
 import { ExitCode, exitWithCode } from '../utils/exit-codes.js';
+import { isCiMode } from '../utils/interaction-mode.js';
 import type { ArgumentsCamelCase } from 'yargs';
 import { autoInstallSkills } from './install-skill.js';
 import { maybeOfferMcpInstall } from '../lib/mcp-notice.js';
@@ -13,8 +14,8 @@ import { maybeOfferMcpInstall } from '../lib/mcp-notice.js';
 export async function handleInstall(argv: ArgumentsCamelCase<InstallerArgs>): Promise<void> {
   const options = { ...argv };
 
-  // CI mode validation
-  if (options.ci) {
+  // CI mode validation — trigger for the hidden --ci flag or WORKOS_MODE=ci.
+  if (options.ci || isCiMode()) {
     if (!options.apiKey) {
       exitWithError({ code: 'missing_args', message: 'CI mode requires --api-key (WorkOS API key sk_xxx)' });
     }

--- a/src/integrations/nextjs/utils.spec.ts
+++ b/src/integrations/nextjs/utils.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { InteractionMode } from '../../utils/interaction-mode.js';
+
+vi.mock('fast-glob', () => ({ default: vi.fn() }));
+
+vi.mock('../../utils/clack.js', () => ({
+  default: {
+    select: vi.fn(),
+    isCancel: vi.fn(() => false),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn(), step: vi.fn(), message: vi.fn() },
+  },
+}));
+
+// Passthrough — the guard itself is covered by clack-utils.spec.ts; here we only
+// need clack.select's resolved value to flow through in the human path.
+vi.mock('../../utils/clack-utils.js', () => ({
+  abortIfCancelled: vi.fn(async (p) => await p),
+}));
+
+const fg = (await import('fast-glob')).default;
+const clack = (await import('../../utils/clack.js')).default;
+const { getNextJsRouter, NextJsRouter } = await import('./utils.js');
+const { setInteractionMode, resetInteractionModeForTests } = await import('../../utils/interaction-mode.js');
+
+/** Configure fast-glob to report presence of pages/ and/or app/ dirs. */
+function mockDetection({ pages, app }: { pages: boolean; app: boolean }): void {
+  vi.mocked(fg).mockImplementation((async (pattern: string) => {
+    if (String(pattern).includes('pages')) return pages ? ['pages/_app.tsx'] : [];
+    return app ? ['app/layout.tsx'] : [];
+  }) as never);
+}
+
+const modes: InteractionMode[] = ['human', 'agent', 'ci'];
+
+describe('getNextJsRouter', () => {
+  beforeEach(() => {
+    resetInteractionModeForTests();
+    vi.clearAllMocks();
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    resetInteractionModeForTests();
+  });
+
+  it.each(modes)('pages-only detection returns pages router without prompting (%s mode)', async (mode) => {
+    setInteractionMode({ mode, source: mode === 'human' ? 'default' : 'env' });
+    mockDetection({ pages: true, app: false });
+
+    const result = await getNextJsRouter({ installDir: '/proj' });
+
+    expect(result).toBe(NextJsRouter.PAGES_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+  });
+
+  it.each(modes)('app-only detection returns app router without prompting (%s mode)', async (mode) => {
+    setInteractionMode({ mode, source: mode === 'human' ? 'default' : 'env' });
+    mockDetection({ pages: false, app: true });
+
+    const result = await getNextJsRouter({ installDir: '/proj' });
+
+    expect(result).toBe(NextJsRouter.APP_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+  });
+
+  it('ambiguous detection in human mode prompts and uses the answer', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    mockDetection({ pages: true, app: true });
+    vi.mocked(clack.select).mockResolvedValueOnce(NextJsRouter.PAGES_ROUTER as never);
+
+    const result = await getNextJsRouter({ installDir: '/proj' });
+
+    expect(result).toBe(NextJsRouter.PAGES_ROUTER);
+    expect(clack.select).toHaveBeenCalledOnce();
+  });
+
+  it('ambiguous detection in agent mode defaults to app router with a warning (no prompt)', async () => {
+    setInteractionMode({ mode: 'agent', source: 'env' });
+    mockDetection({ pages: true, app: true });
+
+    const result = await getNextJsRouter({ installDir: '/proj' });
+
+    expect(result).toBe(NextJsRouter.APP_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(clack.log.warn).toHaveBeenCalled();
+  });
+
+  it('ambiguous detection in ci mode defaults to app router with a warning (no prompt)', async () => {
+    setInteractionMode({ mode: 'ci', source: 'env' });
+    mockDetection({ pages: true, app: true });
+
+    const result = await getNextJsRouter({ installDir: '/proj' });
+
+    expect(result).toBe(NextJsRouter.APP_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(clack.log.warn).toHaveBeenCalled();
+  });
+
+  it('--router pages overrides ambiguous detection with no prompt', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    mockDetection({ pages: true, app: true });
+
+    const result = await getNextJsRouter({ installDir: '/proj', router: 'pages' });
+
+    expect(result).toBe(NextJsRouter.PAGES_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+  });
+
+  it('--router app wins over detection with no prompt', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    mockDetection({ pages: true, app: false });
+
+    const result = await getNextJsRouter({ installDir: '/proj', router: 'app' });
+
+    expect(result).toBe(NextJsRouter.APP_ROUTER);
+    expect(clack.select).not.toHaveBeenCalled();
+  });
+});

--- a/src/integrations/nextjs/utils.ts
+++ b/src/integrations/nextjs/utils.ts
@@ -4,6 +4,7 @@ import clack from '../../utils/clack.js';
 import { getVersionBucket } from '../../utils/semver.js';
 import type { InstallerOptions } from '../../utils/types.js';
 import { IGNORE_PATTERNS } from '../../lib/constants.js';
+import { isPromptAllowed } from '../../utils/interaction-mode.js';
 
 export function getNextJsVersionBucket(version: string | undefined): string {
   return getVersionBucket(version, 11);
@@ -14,7 +15,17 @@ export enum NextJsRouter {
   PAGES_ROUTER = 'pages-router',
 }
 
-export async function getNextJsRouter({ installDir }: Pick<InstallerOptions, 'installDir'>): Promise<NextJsRouter> {
+export async function getNextJsRouter({
+  installDir,
+  router,
+}: Pick<InstallerOptions, 'installDir' | 'router'>): Promise<NextJsRouter> {
+  // Explicit flag wins over detection (deterministic for agents).
+  if (router) {
+    const chosen = router === 'pages' ? NextJsRouter.PAGES_ROUTER : NextJsRouter.APP_ROUTER;
+    clack.log.info(`Using ${getNextJsRouterName(chosen)} (--router)`);
+    return chosen;
+  }
+
   const pagesMatches = await fg('**/pages/_app.@(ts|tsx|js|jsx)', {
     dot: true,
     cwd: installDir,
@@ -38,6 +49,17 @@ export async function getNextJsRouter({ installDir }: Pick<InstallerOptions, 'in
 
   if (hasAppDir && !hasPagesDir) {
     clack.log.info(`Detected ${getNextJsRouterName(NextJsRouter.APP_ROUTER)} 📱`);
+    return NextJsRouter.APP_ROUTER;
+  }
+
+  // Ambiguous (both app/ and pages/ present, or neither). In non-interactive
+  // mode default to the app router (dominant/new-project case) with a warning
+  // instead of prompting — the --router flag above is the escape hatch.
+  if (!isPromptAllowed()) {
+    clack.log.warn(
+      'Could not determine the Next.js router (both app/ and pages/ present, or neither). ' +
+        'Defaulting to app router. Pass --router app|pages to override.',
+    );
     return NextJsRouter.APP_ROUTER;
   }
 

--- a/src/integrations/react-router/utils.spec.ts
+++ b/src/integrations/react-router/utils.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('fast-glob', () => ({ default: vi.fn(async () => []) }));
+
+vi.mock('../../utils/clack.js', () => ({
+  default: {
+    select: vi.fn(),
+    isCancel: vi.fn(() => false),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn(), step: vi.fn(), message: vi.fn() },
+  },
+}));
+
+// Passthrough abortIfCancelled + a package.json with no react-router version, so
+// getReactRouterMode always hits the ambiguous "no version" prompt branch.
+vi.mock('../../utils/clack-utils.js', () => ({
+  abortIfCancelled: vi.fn(async (p) => await p),
+  getPackageDotJson: vi.fn(async () => ({})),
+}));
+
+const clack = (await import('../../utils/clack.js')).default;
+const { getReactRouterMode, ReactRouterMode } = await import('./utils.js');
+const { setInteractionMode, resetInteractionModeForTests } = await import('../../utils/interaction-mode.js');
+
+describe('getReactRouterMode — ambiguous-branch defaults', () => {
+  beforeEach(() => {
+    resetInteractionModeForTests();
+    vi.clearAllMocks();
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    resetInteractionModeForTests();
+  });
+
+  it('agent mode with no detectable version defaults to v7 Framework with a warning (no prompt)', async () => {
+    setInteractionMode({ mode: 'agent', source: 'env' });
+
+    const result = await getReactRouterMode({ installDir: '/proj' } as never);
+
+    expect(result).toBe(ReactRouterMode.V7_FRAMEWORK);
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(clack.log.warn).toHaveBeenCalled();
+  });
+
+  it('ci mode with no detectable version defaults to v7 Framework with a warning (no prompt)', async () => {
+    setInteractionMode({ mode: 'ci', source: 'env' });
+
+    const result = await getReactRouterMode({ installDir: '/proj' } as never);
+
+    expect(result).toBe(ReactRouterMode.V7_FRAMEWORK);
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(clack.log.warn).toHaveBeenCalled();
+  });
+
+  it('human mode with no detectable version prompts and uses the answer', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    vi.mocked(clack.select).mockResolvedValueOnce(ReactRouterMode.V6 as never);
+
+    const result = await getReactRouterMode({ installDir: '/proj' } as never);
+
+    expect(result).toBe(ReactRouterMode.V6);
+    expect(clack.select).toHaveBeenCalledOnce();
+  });
+});

--- a/src/integrations/react-router/utils.ts
+++ b/src/integrations/react-router/utils.ts
@@ -6,6 +6,7 @@ import { getVersionBucket } from '../../utils/semver.js';
 import type { InstallerOptions } from '../../utils/types.js';
 import { IGNORE_PATTERNS } from '../../lib/constants.js';
 import { getPackageVersion } from '../../utils/package-json.js';
+import { isPromptAllowed } from '../../utils/interaction-mode.js';
 import chalk from 'chalk';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -85,6 +86,13 @@ export async function getReactRouterMode(options: InstallerOptions): Promise<Rea
     getPackageVersion('react-router-dom', packageJson) || getPackageVersion('react-router', packageJson);
 
   if (!reactRouterVersion) {
+    if (!isPromptAllowed()) {
+      clack.log.warn(
+        'Could not determine the React Router mode. Defaulting to v7 Framework mode. ' +
+          'Run in an interactive terminal to choose a different mode.',
+      );
+      return ReactRouterMode.V7_FRAMEWORK;
+    }
     clack.log.info(`Learn more about React Router modes: ${chalk.cyan('https://reactrouter.com/start/modes')}`);
     const result: ReactRouterMode = await abortIfCancelled(
       clack.select({
@@ -128,6 +136,13 @@ export async function getReactRouterMode(options: InstallerOptions): Promise<Rea
       return ReactRouterMode.V7_DECLARATIVE;
     }
 
+    if (!isPromptAllowed()) {
+      clack.log.warn(
+        'Could not determine the React Router mode. Defaulting to v7 Framework mode. ' +
+          'Run in an interactive terminal to choose a different mode.',
+      );
+      return ReactRouterMode.V7_FRAMEWORK;
+    }
     clack.log.info(`Learn more about React Router modes: ${chalk.cyan('https://reactrouter.com/start/modes')}`);
     const result: ReactRouterMode = await abortIfCancelled(
       clack.select({
@@ -143,6 +158,13 @@ export async function getReactRouterMode(options: InstallerOptions): Promise<Rea
     return result;
   }
 
+  if (!isPromptAllowed()) {
+    clack.log.warn(
+      'Could not determine the React Router mode. Defaulting to v7 Framework mode. ' +
+        'Run in an interactive terminal to choose a different mode.',
+    );
+    return ReactRouterMode.V7_FRAMEWORK;
+  }
   clack.log.info(`Learn more about React Router modes: ${chalk.cyan('https://reactrouter.com/start/modes')}`);
   const result: ReactRouterMode = await abortIfCancelled(
     clack.select({

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,6 +2,7 @@ import { readEnvironment } from './utils/environment.js';
 import { runWithCore } from './lib/run-with-core.js';
 import type { InstallerOptions } from './utils/types.js';
 import { createInstallerEventEmitter } from './lib/events.js';
+import { isCiMode } from './utils/interaction-mode.js';
 import path from 'path';
 import { EventEmitter } from 'events';
 
@@ -33,6 +34,7 @@ export type InstallerArgs = {
   direct?: boolean;
   scaffold?: boolean;
   pm?: string;
+  router?: 'app' | 'pages';
 };
 
 /**
@@ -58,7 +60,9 @@ function buildOptions(argv: InstallerArgs): InstallerOptions {
     forceInstall: merged.forceInstall ?? false,
     installDir,
     local: merged.local ?? false,
-    ci: merged.ci ?? false,
+    // Bridge WORKOS_MODE=ci to the downstream `options.ci` paths (git checks,
+    // package-manager select) so it fully behaves like the hidden --ci flag.
+    ci: (merged.ci ?? false) || isCiMode(),
     skipAuth: merged.skipAuth ?? false,
     apiKey: merged.apiKey,
     clientId: merged.clientId,
@@ -74,6 +78,7 @@ function buildOptions(argv: InstallerArgs): InstallerOptions {
     direct: merged.direct ?? false,
     scaffold: merged.scaffold ?? false,
     pm: merged.pm,
+    router: merged.router,
     emitter: createInstallerEventEmitter(), // Will be replaced in runWithCore
   };
 }

--- a/src/steps/upload-environment-variables/index.spec.ts
+++ b/src/steps/upload-environment-variables/index.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Force a provider to be detected so we reach the upload decision point.
+// Use a class (not an arrow fn) so `new VercelEnvironmentProvider()` constructs.
+vi.mock('./providers/vercel.js', () => ({
+  VercelEnvironmentProvider: class {
+    name = 'Vercel';
+    detect = vi.fn(async () => true);
+    uploadEnvVars = vi.fn(async () => ({}));
+  },
+}));
+
+vi.mock('../../utils/clack.js', () => ({
+  default: {
+    select: vi.fn(),
+    isCancel: vi.fn(() => false),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn(), step: vi.fn(), message: vi.fn() },
+  },
+}));
+
+vi.mock('../../utils/analytics.js', () => ({
+  analytics: { capture: vi.fn(), shutdown: vi.fn(), setTag: vi.fn() },
+}));
+
+const clack = (await import('../../utils/clack.js')).default;
+const { uploadEnvironmentVariablesStep } = await import('./index.js');
+const { setInteractionMode, resetInteractionModeForTests } = await import('../../utils/interaction-mode.js');
+
+const integration = 'nextjs' as never;
+const options = { installDir: '/proj' } as never;
+
+describe('uploadEnvironmentVariablesStep — non-interactive skip', () => {
+  beforeEach(() => {
+    resetInteractionModeForTests();
+    vi.clearAllMocks();
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    resetInteractionModeForTests();
+  });
+
+  it('ci mode skips the upload prompt and returns []', async () => {
+    setInteractionMode({ mode: 'ci', source: 'env' });
+
+    const result = await uploadEnvironmentVariablesStep({}, { integration, options });
+
+    expect(result).toEqual([]);
+    expect(clack.select).not.toHaveBeenCalled();
+  });
+
+  it('human mode reaches the prompt', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    vi.mocked(clack.select).mockResolvedValueOnce(false as never);
+
+    const result = await uploadEnvironmentVariablesStep({}, { integration, options });
+
+    expect(result).toEqual([]);
+    expect(clack.select).toHaveBeenCalledOnce();
+  });
+});

--- a/src/steps/upload-environment-variables/index.ts
+++ b/src/steps/upload-environment-variables/index.ts
@@ -3,6 +3,7 @@ import { traceStep } from '../../telemetry.js';
 import { analytics } from '../../utils/analytics.js';
 import clack from '../../utils/clack.js';
 import { abortIfCancelled } from '../../utils/clack-utils.js';
+import { isPromptAllowed } from '../../utils/interaction-mode.js';
 import type { InstallerOptions } from '../../utils/types.js';
 import { EnvironmentProvider } from './EnvironmentProvider.js';
 import { VercelEnvironmentProvider } from './providers/vercel.js';
@@ -32,6 +33,18 @@ export const uploadEnvironmentVariablesStep = async (
     analytics.capture('installer interaction', {
       action: 'not uploading environment variables',
       reason: 'no environment provider found',
+      integration,
+    });
+    return [];
+  }
+
+  // Non-interactive mode: default to skipping the upload rather than prompting
+  // (or failing fast via the abortIfCancelled guard below).
+  if (!isPromptAllowed()) {
+    analytics.capture('installer interaction', {
+      action: 'not uploading environment variables',
+      reason: 'non-interactive mode',
+      provider: provider.name,
       integration,
     });
     return [];

--- a/src/utils/clack-utils.spec.ts
+++ b/src/utils/clack-utils.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Locks the Layer-1 invariant of the agent/CI path fix: when prompts are not
+ * allowed (agent/ci/non-TTY), abortIfCancelled must fail fast with a structured
+ * CliExit *without awaiting* the input promise — awaiting a never-resolving
+ * prompt is exactly the hang this guard fixes.
+ */
+
+vi.mock('./clack.js', () => ({
+  default: {
+    isCancel: vi.fn(() => false),
+    cancel: vi.fn(),
+    intro: vi.fn(),
+    outro: vi.fn(),
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      success: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('./analytics.js', () => ({
+  analytics: { shutdown: vi.fn(), setTag: vi.fn(), capture: vi.fn() },
+}));
+
+const clack = (await import('./clack.js')).default;
+const { setInteractionMode, resetInteractionModeForTests } = await import('./interaction-mode.js');
+const { CliExit } = await import('./cli-exit.js');
+const { setOutputMode } = await import('./output.js');
+const { abortIfCancelled } = await import('./clack-utils.js');
+
+describe('abortIfCancelled — non-interactive guard', () => {
+  beforeEach(() => {
+    resetInteractionModeForTests();
+    setOutputMode('human');
+    vi.clearAllMocks();
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    resetInteractionModeForTests();
+    setOutputMode('human');
+  });
+
+  it('agent mode throws CliExit without awaiting the input promise', async () => {
+    setInteractionMode({ mode: 'agent', source: 'env' });
+    // A never-resolving input: if the guard awaited it, this test would time out.
+    await expect(abortIfCancelled(new Promise<never>(() => {}))).rejects.toThrow(CliExit);
+  });
+
+  it('ci mode throws CliExit without awaiting the input promise', async () => {
+    setInteractionMode({ mode: 'ci', source: 'env' });
+    await expect(abortIfCancelled(new Promise<never>(() => {}))).rejects.toThrow(CliExit);
+  });
+
+  it('emits a structured non_interactive_prompt error in JSON mode', async () => {
+    setInteractionMode({ mode: 'agent', source: 'env' });
+    setOutputMode('json');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(abortIfCancelled(new Promise<never>(() => {}))).rejects.toThrow(CliExit);
+
+    expect(errorSpy).toHaveBeenCalled();
+    const payload = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(payload.error.code).toBe('non_interactive_prompt');
+
+    errorSpy.mockRestore();
+  });
+
+  it('human mode passes a resolved value through', async () => {
+    setInteractionMode({ mode: 'human', source: 'default' });
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    await expect(abortIfCancelled('value')).resolves.toBe('value');
+  });
+});

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -17,6 +17,8 @@ import { analytics } from './analytics.js';
 import clack from './clack.js';
 import { INTEGRATION_CONFIG } from '../lib/config.js';
 import { SPAWN_OPTS } from './platform.js';
+import { isPromptAllowed } from './interaction-mode.js';
+import { exitWithError } from './output.js';
 
 /**
  * Redact sensitive info (API keys, client secrets) from a string.
@@ -59,6 +61,28 @@ export async function abortIfCancelled<T>(
   input: T | Promise<T>,
   integration?: Integration,
 ): Promise<Exclude<T, symbol>> {
+  if (!isPromptAllowed()) {
+    // Never await `input` in non-interactive mode — awaiting a never-resolving
+    // prompt is exactly the hang this guard fixes. Fail fast with a structured
+    // error instead. Placed before analytics.shutdown('cancelled') so a
+    // non-interactive block is not mislabeled as a user cancel.
+    exitWithError({
+      code: 'non_interactive_prompt',
+      message:
+        `This step requires interactive input${integration ? ` for ${integration}` : ''}, but the CLI is running ` +
+        `in a non-interactive mode (agent/CI/non-TTY). Pass the required flags (e.g. --router app|pages for Next.js) ` +
+        `or run in an interactive terminal.`,
+      recovery: {
+        hints: [
+          {
+            description:
+              'Re-run in an interactive terminal, or pass the flags that answer this prompt (e.g. --router).',
+          },
+        ],
+      },
+    });
+  }
+
   await analytics.shutdown('cancelled');
   const resolvedInput = await input;
 

--- a/src/utils/help-json.ts
+++ b/src/utils/help-json.ts
@@ -1406,6 +1406,13 @@ const commands: CommandSchema[] = [
         default: true,
         hidden: false,
       },
+      {
+        name: 'router',
+        type: 'string',
+        description: 'Next.js router to target when detection is ambiguous (app or pages)',
+        required: false,
+        hidden: false,
+      },
     ],
   },
   {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -120,6 +120,9 @@ export type InstallerOptions = {
    * Overrides detection from npm_config_user_agent.
    */
   pm?: string;
+
+  /** Next.js router to target when detection is ambiguous (from --router). */
+  router?: 'app' | 'pages';
 };
 
 export interface Feature {


### PR DESCRIPTION
## What

- **Bare `$0` in non-TTY**: `npx workos` with no args now emits the full machine-readable command tree as JSON on stdout (exit 0) instead of a degenerate two-option help dump — the previous handler called `yargs(rawArgs).showHelp()` on a *fresh* yargs instance with no commands registered. Human/TTY mode shows the real configured help via the parser closure.
- **Prompt guard**: `abortIfCancelled` now fails fast with a structured `non_interactive_prompt` error when prompts are disallowed (agent/ci mode), instead of hanging forever on input that will never come. This is a global invariant: any future unguarded prompt dies loudly.
- **Ambiguous router detection**: new `--router app|pages` flag (flag always wins). Without the flag, non-interactive mode defaults to the app router with a warning instead of blocking on a prompt; human mode prompts as before. Same graceful-default treatment for React Router's ambiguous branches and the upload-env-variables prompt.
- **`WORKOS_MODE=ci` bridges `--ci`**: the env var now enforces the same validation and downstream behavior as the hidden `--ci` flag (dirty-tree auto-continue, package-manager auto-select) — previously these were two disconnected notions of "CI".

## Why

From the friction log: these are the first things every CI pipeline and AI agent hits. Bare `npx workos@latest` in a non-TTY shell dead-ended with no discoverable subcommands, and `WORKOS_MODE=ci` installs still blocked forever on the interactive router prompt.

## Testing

- New subprocess integration spec `bin-default-command.integration.spec.ts` (mirrors the telemetry integration harness): agent/JSON, CI, `WORKOS_FORCE_TTY` human, and `--help --json` regression paths.
- New unit specs: `clack-utils.spec.ts` (guard), `nextjs/utils.spec.ts` + `react-router/utils.spec.ts` (ambiguous fixtures across human/ci/flag paths), `upload-environment-variables/index.spec.ts`.
- Full gate green (2,245 tests at this point in the stack) plus end-to-end smoke tests on the built binary.

---

**Stack 3/7** (`akshay-friction-log`): merge after #186, then rebase onto `main`.