### PR TITLE
fix: detect Bun compiled binary when import.meta.url percent-encodes ~BUN

### DIFF
--- a/src/lib/agent-sdk-assets.spec.ts
+++ b/src/lib/agent-sdk-assets.spec.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AGENT_SDK_TARGET, AGENT_SDK_VERSION } from '../generated/agent-sdk-manifest.js';
-import { downloadTarball, ensureClaudeCodeExecutable, extractTarEntry } from './agent-sdk-assets.js';
+import { downloadTarball, ensureClaudeCodeExecutable, extractTarEntry, isBunVirtualFsUrl } from './agent-sdk-assets.js';
 
 function tarHeader(name: string, size: number): Buffer {
   const header = Buffer.alloc(512);
@@ -26,6 +26,25 @@ function makeTarball(entries: Array<[string, Buffer]>): Buffer {
   parts.push(Buffer.alloc(1024)); // end-of-archive
   return gzipSync(Buffer.concat(parts));
 }
+
+describe('isBunVirtualFsUrl', () => {
+  it('detects the POSIX compiled-binary virtual filesystem', () => {
+    expect(isBunVirtualFsUrl('file:///$bunfs/root/workos')).toBe(true);
+  });
+
+  it('detects the Windows virtual filesystem with the tilde percent-encoded', () => {
+    expect(isBunVirtualFsUrl('file:///B:/%7EBUN/root/workos-windows-x64.exe')).toBe(true);
+  });
+
+  it('detects a raw Windows virtual path', () => {
+    expect(isBunVirtualFsUrl('B:\\~BUN\\root\\workos-windows-x64.exe')).toBe(true);
+  });
+
+  it('rejects source-mode module URLs', () => {
+    expect(isBunVirtualFsUrl(import.meta.url)).toBe(false);
+    expect(isBunVirtualFsUrl('file:///home/dev/cli/src/lib/agent-sdk-assets.ts')).toBe(false);
+  });
+});
 
 describe('ensureClaudeCodeExecutable', () => {
   it('resolves the current platform executable from node_modules in source mode', async () => {

--- a/src/lib/agent-sdk-assets.ts
+++ b/src/lib/agent-sdk-assets.ts
@@ -54,9 +54,19 @@ function runtimeTarget(): string {
   return `${process.platform}-${process.arch}${isMuslRuntime() ? '-musl' : ''}`;
 }
 
+/**
+ * Whether a module URL points into a Bun compiled binary's virtual filesystem:
+ * `/$bunfs/` on POSIX, `B:\~BUN\` on Windows — which import.meta.url surfaces
+ * with the tilde percent-encoded (`file:///B:/%7EBUN/root/…`). Exported for
+ * tests.
+ */
+export function isBunVirtualFsUrl(url: string): boolean {
+  return url.includes('$bunfs') || url.includes('~BUN') || url.includes('%7EBUN');
+}
+
 /** Running from a compiled binary: the module graph lives in Bun's virtual filesystem. */
 function isCompiledBinary(): boolean {
-  return import.meta.url.includes('$bunfs') || import.meta.url.includes('~BUN');
+  return isBunVirtualFsUrl(import.meta.url);
 }
 
 function agentSdkCacheRoot(): string {


### PR DESCRIPTION
## Why

The v0.20.0 release failed both Windows smoke tests with:

```
VERIFY_ASSETS_AGENT_SDK_FAILED: Cannot find module
'@anthropic-ai/claude-agent-sdk-win32-x64/package.json' from 'B:\~BUN\root\workos-windows-x64.exe'
```

`isCompiledBinary()` checks `import.meta.url` for `$bunfs` (POSIX) or `~BUN` (Windows). But Bun's URL serializer (WebKit `WTF::URL::fileURLWithFileSystemPath`) percent-encodes the tilde, so on Windows the URL is `file:///B:/%7EBUN/root/…` — neither marker matches. The compiled binary then took the dev-mode path and tried to resolve the Agent SDK from node_modules, which doesn't exist in a standalone binary.

Verified empirically (same serializer as `Bun.pathToFileURL`):

```
$ bun -e 'console.log(Bun.pathToFileURL("/tmp/~BUN/root/x.exe").href)'
file:///tmp/%7EBUN/root/x.exe
```

POSIX targets were unaffected because `$` isn't percent-encoded, which is why all six macOS/Linux smoke tests passed.

## What

- Extract the marker check into `isBunVirtualFsUrl()` and additionally match the percent-encoded `%7EBUN` form.
- Regression tests covering the exact URL shape observed in the failed Windows smoke run.

Note: `Bun.isStandaloneExecutable` is the official API for this, but it shipped after Bun 1.3.14 (the version CI pins), so the URL heuristic stays.

## Verification

- `bun run test` (2033 pass), `bun run typecheck`, `bun run build` all green.
- The real gate is the release pipeline's Windows smoke jobs, which run `internal verify-assets` on real Windows hardware before anything publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)