### PR TITLE
fix(release): hoist install out of the generated formula's on_arm blocks

### DIFF
--- a/scripts/gen-homebrew-formula.ts
+++ b/scripts/gen-homebrew-formula.ts
@@ -61,17 +61,15 @@ for (const platform of PLATFORMS) {
   shas.set(platform.asset, await sha256(platform.asset));
 }
 
-// One `on_arm`/`on_intel` stanza; each pins the URL + sha and installs the raw
-// binary (named after the URL's basename) as `workos`.
+// One `on_arm`/`on_intel` stanza; each pins only the URL + sha. `install` is
+// deliberately NOT defined in here: RuboCop's Sorbet/BlockMethodDefinition
+// (enforced by `brew style` since Homebrew 6.0) rejects `def` inside a block,
+// so a single class-level `def install` globs whichever asset was downloaded.
 function stanza(cpu: 'arm' | 'intel', asset: string): string {
   return [
     `    on_${cpu} do`,
     `      url "${DOWNLOAD_BASE}/${asset}"`,
     `      sha256 "${shas.get(asset)}"`,
-    '',
-    '      def install',
-    `        bin.install "${asset}" => "workos"`,
-    '      end',
     '    end',
   ].join('\n');
 }
@@ -96,6 +94,14 @@ ${macos.map((p) => stanza(p.cpu, p.asset)).join('\n')}
 
   on_linux do
 ${linux.map((p) => stanza(p.cpu, p.asset)).join('\n')}
+  end
+
+  # Exactly one of the four assets above is downloaded, so the glob resolves to
+  # that platform's binary; matches Formula/workos-emulate.rb in the same tap.
+  def install
+    binary = Dir["workos-*"].first
+    odie "No workos-* binary in the staging directory" if binary.nil?
+    bin.install binary => "workos"
   end
 
   test do


### PR DESCRIPTION
## Summary

`brew style workos/tap` fails on `Formula/workos.rb`, which takes `brew test-bot --only-tap-syntax` red on **every** workos/homebrew-tap pull request (e.g. [homebrew-tap#3](https://github.com/workos/homebrew-tap/pull/3), a README-only change).

Homebrew 6.0 enforces RuboCop's `Sorbet/BlockMethodDefinition`, which rejects `def` inside a block. `scripts/gen-homebrew-formula.ts` emits a `def install` inside each `on_arm`/`on_intel` stanza, so the generated formula now trips it four times:

```
Formula/workos.rb:17:7: C: [Correctable] Sorbet/BlockMethodDefinition:
  Do not define methods in blocks (use define_method as a workaround).
      def install ...
```

## Change

Drop `install` from the per-arch stanzas (they now pin only `url` + `sha256`) and emit one class-level `def install` that globs whichever asset the current platform downloaded. This is the same shape as `Formula/workos-emulate.rb`, which is already clean under the new cop — so the tap ends up with one consistent pattern.

```ruby
  def install
    binary = Dir["workos-*"].first
    odie "No workos-* binary in the staging directory" if binary.nil?
    bin.install binary => "workos"
  end
```

The `odie` guard is the one deviation from the emulate formula: a bare `Dir[...].first` returns `nil` on a miss and fails with an opaque error, so this names the cause.

## Verification

Ran the generator with stub binaries, then the full `--only-tap-syntax` suite against a scratch tap built from the real remote `main` with the patched formula dropped in — local brew is **6.0.13**, the same version CI uses:

| step | before | after |
| --- | --- | --- |
| `brew style` | 3 files, **4 offenses** | 3 files, **no offenses** |
| `brew readall --aliases --os=all --arch=all` | pass | pass |
| `brew audit --except=installed` | pass | pass |

## Notes

- Formula-only restructuring — no change to URLs, shas, version stamping, or the release workflow.
- The tap's checked-in `Formula/workos.rb` stays stale until the next release regenerates it, so it needs the same edit by hand to unblock homebrew-tap CI now. Companion PR: workos/homebrew-tap#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)