### PR TITLE
feat: make dashboard environments first-class in the CLI

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,8 +31,8 @@ migration is not another user-visible break. Two rules of that contract:
 The local credential-profile commands (`env add/remove/switch/list/provision/claim`)
 are now `workos profile ...`. The old name collided with the new
 `workos environment` command (dashboard environments), and the two are
-different things: a *profile* is an API key + settings stored on your machine;
-an *environment* is the server-side WorkOS environment it targets.
+different things: a _profile_ is an API key + settings stored on your machine;
+an _environment_ is the server-side WorkOS environment it targets.
 
 `workos env ...` keeps working as an alias — no script changes required. Only
 the canonical name in help text, hints, and telemetry changed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,6 +26,17 @@ migration is not another user-visible break. Two rules of that contract:
 > confirmed; those are flagged inline and listed under
 > [Unconfirmed facts](#unconfirmed-facts).
 
+## Command rename: `workos env` → `workos profile`
+
+The local credential-profile commands (`env add/remove/switch/list/provision/claim`)
+are now `workos profile ...`. The old name collided with the new
+`workos environment` command (dashboard environments), and the two are
+different things: a *profile* is an API key + settings stored on your machine;
+an *environment* is the server-side WorkOS environment it targets.
+
+`workos env ...` keeps working as an alias — no script changes required. Only
+the canonical name in help text, hints, and telemetry changed.
+
 ## Breaking changes at a glance
 
 | Change                    | Old                                                                  | New                                                 | Affected commands                                               |

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ When you run `workos install` without credentials, the CLI automatically provisi
 workos install
 
 # Check your environment
-workos env list
+workos profile list
 # Shows: unclaimed (unclaimed) ← active
 
 # Claim the environment to link it to your WorkOS account
-workos env claim
+workos profile claim
 ```
 
 Management commands work on unclaimed environments with a warning reminding you to claim.
@@ -295,10 +295,10 @@ workos emulate --interactive
 ### Environment Management
 
 ```bash
-workos env add [name] [apiKey]   # Add environment (interactive if no args)
-workos env remove <name>         # Remove an environment
-workos env switch [name]         # Switch active environment
-workos env list                  # List environments with active indicator
+workos profile add [name] [apiKey]   # Add environment (interactive if no args)
+workos profile remove <name>         # Remove an environment
+workos profile switch [name]         # Switch active environment
+workos profile list                  # List environments with active indicator
 ```
 
 API keys are stored in the system keychain via `@napi-rs/keyring`, with a JSON file fallback at `~/.workos/config.json`.
@@ -307,7 +307,7 @@ API keys are stored in the system keychain via `@napi-rs/keyring`, with a JSON f
 
 All resource commands follow the same pattern: `workos <resource> <action> [args] [--options]`.
 
-Most resource commands — organization, user, role, permission, membership, invitation, session, event, feature-flag, org-domain, portal, webhook, config, authkit, branding — authenticate with your WorkOS dashboard session from `workos auth login` and target the active environment (see `workos env`). Pass `--environment-id <id>` on any of them to target a different environment for a single invocation. Access tokens refresh automatically while the session is valid, so a logged-in machine keeps working headlessly; a dead session exits with code 4.
+Most resource commands — organization, user, role, permission, membership, invitation, session, event, feature-flag, org-domain, portal, webhook, config, authkit, branding — authenticate with your WorkOS dashboard session from `workos auth login` and target the active environment (see `workos profile`). Pass `--environment-id <id>` on any of them to target a different environment for a single invocation. Access tokens refresh automatically while the session is valid, so a logged-in machine keeps working headlessly; a dead session exits with code 4.
 
 The remaining commands (`connection`, `directory`, `audit-log`, `api-key`, `vault`) still use the REST plane, as does the raw escape hatch `workos api`. Those resolve an API key via: `--api-key` flag → `WORKOS_API_KEY` env var → active environment's stored key.
 
@@ -600,7 +600,7 @@ All commands produce structured JSON when piped or with `--json`:
 workos org list | jq .
 # → { "organizations": [...], "pagination": { "before": null, "after": "..." } }
 
-workos env list --json
+workos profile list --json
 # → { "data": [{ "name": "prod", "type": "production", "active": true, ... }] }
 ```
 
@@ -675,7 +675,7 @@ Agents can introspect available commands:
 
 ```bash
 workos --help --json              # Full command tree
-workos env --help --json          # Subcommand tree
+workos profile --help --json          # Subcommand tree
 workos organization --help --json # With positionals and option types
 ```
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -430,72 +430,76 @@ async function runCli(): Promise<void> {
         await runWhoami({ environmentId: argv.environmentId as string | undefined });
       },
     )
-    .command('environment', 'Manage WorkOS environments (list, use, create, rename) on the dashboard account plane', (yargs) => {
-      yargs.options(insecureStorageOption);
-      registerSubcommand(
-        yargs,
-        'list',
-        "List the current team's environments",
-        (y) => y,
-        async () => {
-          const { runEnvironmentList } = await import('./commands/environment.js');
-          await runEnvironmentList();
-        },
-      );
-      registerSubcommand(
-        yargs,
-        'use [environmentId]',
-        'Point the active environment profile at a team environment',
-        (y) =>
-          y.positional('environmentId', {
-            type: 'string',
-            describe: 'Environment ID to target (see `environment list`); omit to pick interactively',
-          }),
-        async (argv) => {
-          await applyInsecureStorage(argv.insecureStorage);
-          const { runEnvironmentUse } = await import('./commands/environment.js');
-          await runEnvironmentUse(argv.environmentId);
-        },
-      );
-      registerSubcommand(
-        yargs,
-        'create <name>',
-        'Create a sandbox or production environment',
-        (y) =>
-          y
-            .positional('name', { type: 'string', demandOption: true, describe: 'Environment name' })
-            .option('sandbox', { type: 'boolean', default: false, describe: 'Create a sandbox environment' })
-            .option('environment-id', {
+    .command(
+      'environment',
+      'Manage WorkOS environments (list, use, create, rename) on the dashboard account plane',
+      (yargs) => {
+        yargs.options(insecureStorageOption);
+        registerSubcommand(
+          yargs,
+          'list',
+          "List the current team's environments",
+          (y) => y,
+          async () => {
+            const { runEnvironmentList } = await import('./commands/environment.js');
+            await runEnvironmentList();
+          },
+        );
+        registerSubcommand(
+          yargs,
+          'use [environmentId]',
+          'Point the active environment profile at a team environment',
+          (y) =>
+            y.positional('environmentId', {
               type: 'string',
-              describe:
-                'Environment ID whose project receives the new environment (defaults to the active environment)',
+              describe: 'Environment ID to target (see `environment list`); omit to pick interactively',
             }),
-        async (argv) => {
-          await applyInsecureStorage(argv.insecureStorage);
-          const { runEnvironmentCreate } = await import('./commands/environment.js');
-          await runEnvironmentCreate({
-            name: argv.name,
-            sandbox: Boolean(argv.sandbox),
-            environmentId: argv.environmentId as string | undefined,
-          });
-        },
-      );
-      registerSubcommand(
-        yargs,
-        'rename <environmentId> <name>',
-        'Rename an environment',
-        (y) =>
-          y
-            .positional('environmentId', { type: 'string', demandOption: true, describe: 'Environment ID' })
-            .positional('name', { type: 'string', demandOption: true, describe: 'New environment name' }),
-        async (argv) => {
-          await applyInsecureStorage(argv.insecureStorage);
-          const { runEnvironmentRename } = await import('./commands/environment.js');
-          await runEnvironmentRename({ environmentId: argv.environmentId, name: argv.name });
-        },
-      );
-      return yargs.demandCommand(1, 'Please specify an environment subcommand').strict();
-    })
+          async (argv) => {
+            await applyInsecureStorage(argv.insecureStorage);
+            const { runEnvironmentUse } = await import('./commands/environment.js');
+            await runEnvironmentUse(argv.environmentId);
+          },
+        );
+        registerSubcommand(
+          yargs,
+          'create <name>',
+          'Create a sandbox or production environment',
+          (y) =>
+            y
+              .positional('name', { type: 'string', demandOption: true, describe: 'Environment name' })
+              .option('sandbox', { type: 'boolean', default: false, describe: 'Create a sandbox environment' })
+              .option('environment-id', {
+                type: 'string',
+                describe:
+                  'Environment ID whose project receives the new environment (defaults to the active environment)',
+              }),
+          async (argv) => {
+            await applyInsecureStorage(argv.insecureStorage);
+            const { runEnvironmentCreate } = await import('./commands/environment.js');
+            await runEnvironmentCreate({
+              name: argv.name,
+              sandbox: Boolean(argv.sandbox),
+              environmentId: argv.environmentId as string | undefined,
+            });
+          },
+        );
+        registerSubcommand(
+          yargs,
+          'rename <environmentId> <name>',
+          'Rename an environment',
+          (y) =>
+            y
+              .positional('environmentId', { type: 'string', demandOption: true, describe: 'Environment ID' })
+              .positional('name', { type: 'string', demandOption: true, describe: 'New environment name' }),
+          async (argv) => {
+            await applyInsecureStorage(argv.insecureStorage);
+            const { runEnvironmentRename } = await import('./commands/environment.js');
+            await runEnvironmentRename({ environmentId: argv.environmentId, name: argv.name });
+          },
+        );
+        return yargs.demandCommand(1, 'Please specify an environment subcommand').strict();
+      },
+    )
     .command('project', 'Manage WorkOS projects (create, rename, list) on the dashboard account plane', (yargs) => {
       yargs.options(insecureStorageOption);
       registerSubcommand(

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -287,7 +287,7 @@ async function runCli(): Promise<void> {
     .scriptName('workos')
     .parserConfiguration({ 'populate--': true })
     .exitProcess(false)
-    .fail((msg, err) => {
+    .fail((msg, err, failedParser) => {
       if (err instanceof CliExit) throw err;
       // yargs runs its demand/strict validation before dispatching middleware,
       // so the command-name middleware below has not run yet and commandName is
@@ -300,6 +300,15 @@ async function runCli(): Promise<void> {
         commandName = resolveCommandNameFromRawArgs(rawArgs);
       }
       if (msg) {
+        // Human mode: show contextual usage (the failing command's subtree)
+        // before the error, like every other CLI. Help goes to STDOUT ('log'):
+        // per clig.dev help is output, not messaging — and Bun paints all
+        // console.error output red, which must only apply to the error line.
+        // JSON mode keeps the structured error as the only output.
+        if (!isJsonMode()) {
+          failedParser?.showHelp('log');
+          console.log('');
+        }
         outputError({ code: 'invalid_usage', message: msg });
       }
       throw new CliExit(ExitCode.GENERAL_ERROR, { reason: 'validation_error' });
@@ -421,8 +430,33 @@ async function runCli(): Promise<void> {
         await runWhoami({ environmentId: argv.environmentId as string | undefined });
       },
     )
-    .command('environment', 'Manage WorkOS environments (create, rename) on the dashboard account plane', (yargs) => {
+    .command('environment', 'Manage WorkOS environments (list, use, create, rename) on the dashboard account plane', (yargs) => {
       yargs.options(insecureStorageOption);
+      registerSubcommand(
+        yargs,
+        'list',
+        "List the current team's environments",
+        (y) => y,
+        async () => {
+          const { runEnvironmentList } = await import('./commands/environment.js');
+          await runEnvironmentList();
+        },
+      );
+      registerSubcommand(
+        yargs,
+        'use [environmentId]',
+        'Point the active environment profile at a team environment',
+        (y) =>
+          y.positional('environmentId', {
+            type: 'string',
+            describe: 'Environment ID to target (see `environment list`); omit to pick interactively',
+          }),
+        async (argv) => {
+          await applyInsecureStorage(argv.insecureStorage);
+          const { runEnvironmentUse } = await import('./commands/environment.js');
+          await runEnvironmentUse(argv.environmentId);
+        },
+      );
       registerSubcommand(
         yargs,
         'create <name>',
@@ -1077,7 +1111,7 @@ async function runCli(): Promise<void> {
       },
     )
     // NOTE: When adding commands here, also update src/utils/help-json.ts
-    .command('env', 'Manage environment configurations (API keys, endpoints, active environment)', (yargs) => {
+    .command(['profile', 'env'], 'Manage local environment profiles (API keys, endpoints, active profile)', (yargs) => {
       yargs.options(insecureStorageOption);
       registerSubcommand(
         yargs,
@@ -1120,7 +1154,7 @@ async function runCli(): Promise<void> {
           if (!argv.name && !isPromptAllowed()) {
             exitWithError({
               code: 'missing_args',
-              message: `Environment name required. Usage: ${formatWorkOSCommand('env switch <name>')}`,
+              message: `Environment name required. Usage: ${formatWorkOSCommand('profile switch <name>')}`,
             });
           }
           await applyInsecureStorage(argv.insecureStorage);
@@ -1161,7 +1195,7 @@ async function runCli(): Promise<void> {
           await runEnvProvision();
         },
       );
-      return yargs.demandCommand(1, 'Please specify an env subcommand').strict();
+      return yargs.demandCommand(1, 'Please specify a profile subcommand').strict();
     })
     .command(
       'api [endpoint] [filter]',
@@ -3064,7 +3098,7 @@ async function runCli(): Promise<void> {
         await runDebugSync(argv.directoryId, resolveApiKey({ apiKey: argv.apiKey }), resolveApiBaseUrl());
       },
     )
-    // Alias — canonical command is `workos env claim`
+    // Alias — canonical command is `workos profile claim`
     .command(
       'claim',
       'Claim an unclaimed WorkOS environment — link it to your account (permanent — cannot be undone)',
@@ -3324,7 +3358,9 @@ async function runCli(): Promise<void> {
             // Same 64KiB pipe-buffer truncation as the --help --json intercept.
             outputJsonSync(buildCommandTree());
           } else {
-            parser.showHelp();
+            // 'log' = stdout: help is output (clig.dev), and Bun would paint
+            // the default console.error sink red.
+            parser.showHelp('log');
           }
           return;
         }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -353,8 +353,9 @@ async function runCli(): Promise<void> {
     .middleware(async (argv) => {
       // Warn about unclaimed environments before management commands.
       // Excluded: auth/claim/install/setup/dashboard handle their own credential
-      // or onboarding flows; skills/doctor/env/debug are utility commands where
-      // the warning is unnecessary.
+      // or onboarding flows; skills/doctor/profile/debug are utility commands
+      // where the warning is unnecessary. Both the canonical name and its
+      // alias are listed — this matches argv._[0], the token as typed.
       const command = String(argv._?.[0] ?? '');
       if (
         [
@@ -362,6 +363,7 @@ async function runCli(): Promise<void> {
           'whoami',
           'skills',
           'doctor',
+          'profile',
           'env',
           'claim',
           'install',

--- a/src/catalog/manifest.ts
+++ b/src/catalog/manifest.ts
@@ -19,6 +19,9 @@ import type { CommandJustification } from './manifest-types.js';
  */
 const MANIFEST: CommandJustification[] = [
   // --- environment ---
+  // (`environment list` / `environment use` ride the shared `teamProjectsV2`
+  // read curated as `project list` — the manifest is one command noun per op,
+  // so composite/local commands like these and `whoami` have no entry.)
   {
     command: 'environment create',
     mapsTo: 'createEnvironment',

--- a/src/commands/claim.spec.ts
+++ b/src/commands/claim.spec.ts
@@ -491,7 +491,7 @@ describe('claim command', () => {
         await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 5_000);
         await claimPromise;
 
-        expect(mockUi.log.info).toHaveBeenCalledWith(expect.stringContaining('workos env list'));
+        expect(mockUi.log.info).toHaveBeenCalledWith(expect.stringContaining('workos profile list'));
       } finally {
         for (const k of NPM_KEYS) {
           if (saved[k] === undefined) delete process.env[k];

--- a/src/commands/claim.ts
+++ b/src/commands/claim.ts
@@ -143,14 +143,14 @@ export async function runClaim(): Promise<void> {
     }
 
     spinner.stop('Claim timed out');
-    ui.log.info(`Complete the claim in your browser, then run \`${formatWorkOSCommand('env list')}\` to verify.`);
+    ui.log.info(`Complete the claim in your browser, then run \`${formatWorkOSCommand('profile list')}\` to verify.`);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     logError('[claim] Error:', message);
     exitWithError({
       code: 'claim_failed',
       message: `Could not claim this environment: ${message}`,
-      recovery: networkRetryRecovery({ command: formatWorkOSCommand('env claim') }),
+      recovery: networkRetryRecovery({ command: formatWorkOSCommand('profile claim') }),
     });
   }
 }

--- a/src/commands/env.spec.ts
+++ b/src/commands/env.spec.ts
@@ -337,6 +337,23 @@ describe('env commands', () => {
       logSpy.mockRestore();
     });
 
+    it('shows the dashboard environment name in the table, falling back to the ID', async () => {
+      await runEnvAdd({ name: 'prod', apiKey: 'sk_live_abc' });
+      await runEnvAdd({ name: 'legacy', apiKey: 'sk_live_def' });
+      const config = getConfig()!;
+      config.environments.prod.environmentId = 'environment_123';
+      config.environments.prod.environmentName = 'Production';
+      config.environments.legacy.environmentId = 'environment_456';
+      saveConfig(config);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await runEnvList();
+      const lines = logSpy.mock.calls.map((c) => c.map(String).join(' '));
+      expect(lines.some((l) => l.includes('Environment'))).toBe(true);
+      expect(lines.some((l) => l.includes('prod') && l.includes('Production'))).toBe(true);
+      expect(lines.some((l) => l.includes('legacy') && l.includes('environment_456'))).toBe(true);
+      logSpy.mockRestore();
+    });
+
     it('does not print an override annotation when no env var is set', async () => {
       await runEnvAdd({ name: 'prod', apiKey: 'sk_live_abc' });
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -470,7 +487,7 @@ describe('env commands', () => {
       await runEnvProvision();
 
       expect(consoleOutput.join('\n')).toContain('sk_test_x');
-      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('env claim'));
+      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('profile claim'));
     });
   });
 
@@ -571,6 +588,21 @@ describe('env commands', () => {
       expect(output.data[0].active).toBe(true);
       expect(output.data[1].name).toBe('sandbox');
       expect(output.data[1].active).toBe(false);
+      expect(output.data[0].environmentId).toBeNull();
+      expect(output.data[0].environmentName).toBeNull();
+    });
+
+    it('runEnvList includes the stored environmentId and environmentName per profile', async () => {
+      await runEnvAdd({ name: 'prod', apiKey: 'sk_live_abc' });
+      const config = getConfig()!;
+      config.environments.prod.environmentId = 'environment_123';
+      config.environments.prod.environmentName = 'Production';
+      saveConfig(config);
+      consoleOutput = [];
+      await runEnvList();
+      const output = JSON.parse(consoleOutput[0]);
+      expect(output.data[0].environmentId).toBe('environment_123');
+      expect(output.data[0].environmentName).toBe('Production');
     });
 
     it('runEnvList outputs empty data array when no environments', async () => {
@@ -619,14 +651,14 @@ describe('env commands', () => {
 
     it('runEnvList empty hint uses the bare command when not launched via npx', async () => {
       await runEnvList();
-      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('workos env add'));
+      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('workos profile add'));
       expect(ui.log.info).not.toHaveBeenCalledWith(expect.stringContaining('npx workos@latest'));
     });
 
     it('runEnvList empty hint keeps the standalone binary form when npm variables are present', async () => {
       process.env.npm_command = 'exec';
       await runEnvList();
-      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('workos env add'));
+      expect(ui.log.info).toHaveBeenCalledWith(expect.stringContaining('workos profile add'));
     });
 
     it('unclaimed-table footer keeps the standalone binary form when npm variables are present', async () => {
@@ -648,7 +680,7 @@ describe('env commands', () => {
         out.push(args.map(String).join(' '));
       });
       await runEnvList();
-      expect(out.join('\n')).toContain('workos env claim');
+      expect(out.join('\n')).toContain('workos profile claim');
     });
 
     it('runEnvSwitch no-envs JSON error keeps the standalone binary form with npm variables present', async () => {
@@ -659,7 +691,7 @@ describe('env commands', () => {
       try {
         await expect(runEnvSwitch('anything')).rejects.toThrow(CliExit);
         const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
-        expect(parsed.error.message).toContain('workos env add');
+        expect(parsed.error.message).toContain('workos profile add');
       } finally {
         errorSpy.mockRestore();
         setOutputMode('human');

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -47,7 +47,7 @@ export async function runEnvAdd(options: {
     exitWithError({
       code: 'missing_args',
       message: isAgentMode()
-        ? `Name and API key required in agent mode. Example: ${formatWorkOSCommand('env add staging sk_test_xxx --client-id client_xxx')}`
+        ? `Name and API key required in agent mode. Example: ${formatWorkOSCommand('profile add staging sk_test_xxx --client-id client_xxx')}`
         : isCiMode()
           ? 'Name and API key required in CI mode.'
           : 'Name and API key required when prompting is unavailable.',
@@ -139,7 +139,7 @@ export async function runEnvAdd(options: {
  * Calls the low-level `provisionUnclaimedEnvironment()` directly (no auth, no
  * code-gen). Credentials are delivered on stdout (JSON is the agent credential
  * channel) and persisted locally as an unclaimed env so a follow-up
- * `env claim` works. NEVER writes to the project directory or any `.env` file,
+ * `profile claim` works. NEVER writes to the project directory or any `.env` file,
  * and NEVER falls back to an interactive login on failure.
  */
 export async function runEnvProvision(): Promise<void> {
@@ -193,10 +193,10 @@ export async function runEnvProvision(): Promise<void> {
   console.log(`  ${chalk.dim('AuthKit')}     ${result.authkitDomain}`);
   console.log('');
   ui.log.info(
-    `Set as active environment (${key}). Run \`${formatWorkOSCommand('env claim')}\` to link it to your account (permanent).`,
+    `Set as active environment (${key}). Run \`${formatWorkOSCommand('profile claim')}\` to link it to your account (permanent).`,
   );
   if (key !== 'unclaimed') {
-    ui.log.info(`Your earlier unclaimed environment(s) are kept. See \`${formatWorkOSCommand('env list')}\`.`);
+    ui.log.info(`Your earlier unclaimed environment(s) are kept. See \`${formatWorkOSCommand('profile list')}\`.`);
   }
 }
 
@@ -205,7 +205,7 @@ export async function runEnvRemove(name: string): Promise<void> {
   if (!config || Object.keys(config.environments).length === 0) {
     exitWithError({
       code: 'no_environments',
-      message: `No environments configured. Run \`${formatWorkOSCommand('env add')}\` to get started.`,
+      message: `No environments configured. Run \`${formatWorkOSCommand('profile add')}\` to get started.`,
     });
   }
 
@@ -250,7 +250,7 @@ export async function runEnvSwitch(name?: string): Promise<void> {
   if (!config || Object.keys(config.environments).length === 0) {
     exitWithError({
       code: 'no_environments',
-      message: `No environments configured. Run \`${formatWorkOSCommand('env add')}\` to get started.`,
+      message: `No environments configured. Run \`${formatWorkOSCommand('profile add')}\` to get started.`,
     });
   }
 
@@ -266,7 +266,8 @@ export async function runEnvSwitch(name?: string): Promise<void> {
       if (env.type === 'sandbox') label += ` [Sandbox]`;
       if (env.endpoint) label += ` [${env.endpoint}]`;
       if (key === config.activeEnvironment) label += chalk.green(' (active)');
-      return { value: key, label };
+      const environment = env.environmentName ?? env.environmentId;
+      return { value: key, label, ...(environment && { hint: environment }) };
     });
 
     const selected = await ui.select({
@@ -307,7 +308,7 @@ export async function runEnvList(): Promise<void> {
     if (isJsonMode()) {
       outputJson({ data: [] });
     } else {
-      ui.log.info(`No environments configured. Run \`${formatWorkOSCommand('env add')}\` to get started.`);
+      ui.log.info(`No environments configured. Run \`${formatWorkOSCommand('profile add')}\` to get started.`);
     }
     return;
   }
@@ -326,6 +327,8 @@ export async function runEnvList(): Promise<void> {
       endpoint: env.endpoint ?? null,
       hasApiKey: !!env.apiKey,
       hasClientId: !!env.clientId,
+      environmentId: env.environmentId ?? null,
+      environmentName: env.environmentName ?? null,
     }));
     outputJson({ data, override });
     return;
@@ -336,12 +339,14 @@ export async function runEnvList(): Promise<void> {
   const nameW =
     Math.max(6, ...entries.map(([k, env]) => k.length + (isUnclaimedEnvironment(env) ? ' (unclaimed)'.length : 0))) + 2;
   const typeW = 12;
+  const endpointW = Math.max(8, ...entries.map(([, env]) => (env.endpoint ?? 'default').length)) + 2;
 
   const header = [
     chalk.yellow('  '),
     chalk.yellow('Name'.padEnd(nameW)),
     chalk.yellow('Type'.padEnd(typeW)),
-    chalk.yellow('Endpoint'),
+    chalk.yellow('Endpoint'.padEnd(endpointW)),
+    chalk.yellow('Environment'),
   ].join('  ');
 
   const separator = chalk.dim('─'.repeat(header.length));
@@ -354,16 +359,24 @@ export async function runEnvList(): Promise<void> {
     const marker = isActive ? chalk.green('▸ ') : '  ';
     const unclaimed = isUnclaimedEnvironment(env);
     const displayName = unclaimed ? `${key} ${chalk.yellow('(unclaimed)')}` : key;
-    const name = isActive ? chalk.green(displayName.padEnd(nameW)) : displayName.padEnd(nameW);
+    // Pad by VISIBLE length: displayName may carry ANSI color codes, which
+    // padEnd would count as width and skew every column after Name.
+    const visibleLength = key.length + (unclaimed ? ' (unclaimed)'.length : 0);
+    const padding = ' '.repeat(Math.max(0, nameW - visibleLength));
+    const name = (isActive ? chalk.green(displayName) : displayName) + padding;
     const type = unclaimed ? 'Unclaimed' : env.type === 'sandbox' ? 'Sandbox' : 'Production';
-    const endpoint = env.endpoint || chalk.dim('default');
+    const endpointRaw = (env.endpoint ?? 'default').padEnd(endpointW);
+    const endpoint = env.endpoint ? endpointRaw : chalk.dim(endpointRaw);
+    // Name-first: the dashboard name is what users recognize; fall back to
+    // the raw ID for profiles resolved before names were stored.
+    const environment = env.environmentName ?? env.environmentId ?? chalk.dim('—');
 
-    console.log([marker, name, type.padEnd(typeW), endpoint].join('  '));
+    console.log([marker, name, type.padEnd(typeW), endpoint, environment].join('  '));
   }
 
   if (hasUnclaimed) {
     console.log('');
-    console.log(chalk.dim(`  Run \`${formatWorkOSCommand('env claim')}\` to keep this environment.`));
+    console.log(chalk.dim(`  Run \`${formatWorkOSCommand('profile claim')}\` to keep this environment.`));
   }
 
   if (override) {

--- a/src/commands/environment.spec.ts
+++ b/src/commands/environment.spec.ts
@@ -47,9 +47,8 @@ vi.mock('../lib/config-store.js', async (importActual) => {
 const { setOutputMode } = await import('../utils/output.js');
 const { DashboardGraphqlError } = await import('../lib/dashboard-graphql.js');
 const { CliExit } = await import('../utils/cli-exit.js');
-const { runEnvironmentCreate, runEnvironmentRename, runEnvironmentList, runEnvironmentUse } = await import(
-  './environment.js'
-);
+const { runEnvironmentCreate, runEnvironmentRename, runEnvironmentList, runEnvironmentUse } =
+  await import('./environment.js');
 
 const TEAM_DATA = {
   currentTeam: {
@@ -209,7 +208,9 @@ describe('environment command', () => {
       });
       mockGraphqlRequest.mockResolvedValue({
         currentTeam: {
-          projectsV2: [{ name: 'P1', environments: [{ id: 'env_2', name: 'Prod', sandbox: false, clientId: 'client_2' }] }],
+          projectsV2: [
+            { name: 'P1', environments: [{ id: 'env_2', name: 'Prod', sandbox: false, clientId: 'client_2' }] },
+          ],
         },
       });
       await runEnvironmentList();

--- a/src/commands/environment.spec.ts
+++ b/src/commands/environment.spec.ts
@@ -22,18 +22,55 @@ vi.mock('../lib/dashboard-graphql.js', async (importActual) => {
 // The resolver's own matrix lives in environment-target.spec.ts; commands only
 // need to prove they thread its output into the request (variable + header).
 const mockResolveEnvironmentTarget = vi.fn();
+const mockPromptForEnvironment = vi.fn();
 vi.mock('../lib/environment-target.js', async (importActual) => {
   const actual = await importActual<typeof import('../lib/environment-target.js')>();
   return {
     ...actual,
     resolveEnvironmentTarget: (...args: unknown[]) => mockResolveEnvironmentTarget(...args),
+    promptForEnvironment: (...args: unknown[]) => mockPromptForEnvironment(...args),
+  };
+});
+
+// `use` writes the choice to the local profile; keep the store in-memory.
+const mockGetConfig = vi.fn();
+const mockSetProfileEnvironmentId = vi.fn();
+vi.mock('../lib/config-store.js', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/config-store.js')>();
+  return {
+    ...actual,
+    getConfig: () => mockGetConfig(),
+    setProfileEnvironmentId: (...args: unknown[]) => mockSetProfileEnvironmentId(...args),
   };
 });
 
 const { setOutputMode } = await import('../utils/output.js');
 const { DashboardGraphqlError } = await import('../lib/dashboard-graphql.js');
 const { CliExit } = await import('../utils/cli-exit.js');
-const { runEnvironmentCreate, runEnvironmentRename } = await import('./environment.js');
+const { runEnvironmentCreate, runEnvironmentRename, runEnvironmentList, runEnvironmentUse } = await import(
+  './environment.js'
+);
+
+const TEAM_DATA = {
+  currentTeam: {
+    projectsV2: [
+      {
+        name: 'P1',
+        environments: [
+          { id: 'env_targeted', name: 'Staging', sandbox: true },
+          { id: 'env_2', name: 'Prod', sandbox: false },
+        ],
+      },
+    ],
+  },
+};
+
+const ACTIVE_CONFIG = {
+  activeEnvironment: 'staging',
+  environments: {
+    staging: { name: 'staging', type: 'sandbox', apiKey: 'sk_test_x', environmentId: 'env_targeted' },
+  },
+};
 
 describe('environment command', () => {
   let consoleOutput: string[];
@@ -45,6 +82,7 @@ describe('environment command', () => {
       environmentId: opts.flagValue ?? 'env_profile',
       source: opts.flagValue ? 'flag' : 'profile',
     }));
+    mockGetConfig.mockReturnValue(ACTIVE_CONFIG);
     consoleOutput = [];
     vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
       consoleOutput.push(args.map(String).join(' '));
@@ -150,6 +188,82 @@ describe('environment command', () => {
       await runEnvironmentRename({ environmentId: 'env_1', name: 'Renamed' });
       const out = JSON.parse(consoleOutput[0]);
       expect(out.environment.name).toBe('Renamed');
+    });
+  });
+
+  describe('list', () => {
+    it('flattens projects into environments and marks the one the active profile targets', async () => {
+      mockGraphqlRequest.mockResolvedValue(TEAM_DATA);
+      await runEnvironmentList();
+      const out = consoleOutput.join('\n');
+      expect(out).toContain('Staging');
+      expect(out).toContain('env_targeted');
+      expect(out).toContain('P1');
+      expect(out).toMatch(/▸\s+Staging/);
+    });
+
+    it('heals stored profiles from the fetched list', async () => {
+      mockGetConfig.mockReturnValue({
+        activeEnvironment: 'staging',
+        environments: { staging: { name: 'staging', type: 'sandbox', apiKey: 'k', clientId: 'client_2' } },
+      });
+      mockGraphqlRequest.mockResolvedValue({
+        currentTeam: {
+          projectsV2: [{ name: 'P1', environments: [{ id: 'env_2', name: 'Prod', sandbox: false, clientId: 'client_2' }] }],
+        },
+      });
+      await runEnvironmentList();
+      expect(mockSetProfileEnvironmentId).toHaveBeenCalledWith('staging', 'env_2', 'Prod');
+    });
+
+    it('outputs JSON in json mode', async () => {
+      setOutputMode('json');
+      mockGraphqlRequest.mockResolvedValue(TEAM_DATA);
+      await runEnvironmentList();
+      const out = JSON.parse(consoleOutput[0]);
+      expect(out.environments).toHaveLength(2);
+      expect(out.environments[0]).toEqual({
+        id: 'env_targeted',
+        name: 'Staging',
+        sandbox: true,
+        project: 'P1',
+        targeted: true,
+      });
+      expect(out.environments[1].targeted).toBe(false);
+    });
+  });
+
+  describe('use', () => {
+    it('persists an explicit environment ID onto the active profile', async () => {
+      mockGraphqlRequest.mockResolvedValue(TEAM_DATA);
+      await runEnvironmentUse('env_2');
+      expect(mockSetProfileEnvironmentId).toHaveBeenCalledWith('staging', 'env_2', 'Prod');
+      expect(consoleOutput.join('\n')).toContain('Prod');
+    });
+
+    it('rejects an unknown environment ID without writing', async () => {
+      mockGraphqlRequest.mockResolvedValue(TEAM_DATA);
+      await expect(runEnvironmentUse('env_nope')).rejects.toMatchObject({
+        name: 'CliExit',
+        context: { errorCode: 'not_found' },
+      });
+      expect(mockSetProfileEnvironmentId).not.toHaveBeenCalled();
+    });
+
+    it('persists the picker choice when no ID is given', async () => {
+      mockGraphqlRequest.mockResolvedValue(TEAM_DATA);
+      mockPromptForEnvironment.mockResolvedValue('env_2');
+      await runEnvironmentUse();
+      expect(mockSetProfileEnvironmentId).toHaveBeenCalledWith('staging', 'env_2', 'Prod');
+    });
+
+    it('exits when there is no active profile', async () => {
+      mockGetConfig.mockReturnValue({ environments: {} });
+      await expect(runEnvironmentUse('env_2')).rejects.toMatchObject({
+        name: 'CliExit',
+        context: { errorCode: 'no_active_environment' },
+      });
+      expect(mockGraphqlRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/environment.ts
+++ b/src/commands/environment.ts
@@ -86,7 +86,12 @@ export async function runEnvironmentList(): Promise<void> {
     env.projectName ?? '—',
     env.sandbox ? 'Sandbox' : 'Production',
   ]);
-  console.log(formatTable([{ header: '' }, { header: 'Name' }, { header: 'ID' }, { header: 'Project' }, { header: 'Type' }], rows));
+  console.log(
+    formatTable(
+      [{ header: '' }, { header: 'Name' }, { header: 'ID' }, { header: 'Project' }, { header: 'Type' }],
+      rows,
+    ),
+  );
 
   const profileName = getConfig()?.activeEnvironment;
   if (targetedId && profileName) {

--- a/src/commands/environment.ts
+++ b/src/commands/environment.ts
@@ -14,13 +14,136 @@
  */
 
 import chalk from 'chalk';
-import { runEnvScopedOperation } from '../lib/dashboard-operation.js';
-import { isJsonMode, outputJson, outputSuccess } from '../utils/output.js';
+import { runEnvScopedOperation, runTeamScopedOperation } from '../lib/dashboard-operation.js';
+import { requireCommandToken } from '../lib/command-auth.js';
+import {
+  fetchTeamEnvironments,
+  healProfiles,
+  promptForEnvironment,
+  type TeamEnvironment,
+} from '../lib/environment-target.js';
+import { getConfig, setProfileEnvironmentId } from '../lib/config-store.js';
+import { reportDashboardError } from '../catalog/operation.js';
+import { isJsonMode, outputJson, outputSuccess, exitWithError } from '../utils/output.js';
+import { isPromptAllowed } from '../utils/interaction-mode.js';
+import { formatWorkOSCommand } from '../utils/command-invocation.js';
+import { ExitCode, exitWithCode } from '../utils/exit-codes.js';
+import { formatTable } from '../utils/table.js';
 
 interface EnvironmentNode {
   id: string;
   name: string | null;
   sandbox?: boolean | null;
+  clientId?: string | null;
+}
+
+interface ProjectWithEnvironments {
+  name: string | null;
+  environments: EnvironmentNode[] | null;
+}
+
+export async function runEnvironmentList(): Promise<void> {
+  // Team-scoped read: deliberately NO environment header (see environment-target.ts).
+  const { data } = await runTeamScopedOperation<{
+    currentTeam: { projectsV2: ProjectWithEnvironments[] | null } | null;
+  }>('teamProjectsV2');
+
+  const projects = data.currentTeam?.projectsV2 ?? [];
+  const nodes = projects.flatMap((project) =>
+    (project.environments ?? []).map((env) => ({ ...env, projectName: project.name })),
+  );
+
+  // The list is fresh in hand — heal before marking so the ▸ reflects any
+  // just-repaired targeting, and so a stale name never survives this command.
+  healProfiles(getConfig(), nodes);
+  // Re-read post-heal: the marker must reflect any just-repaired targeting.
+  const after = getConfig();
+  const targetedId = after?.activeEnvironment ? after.environments[after.activeEnvironment]?.environmentId : undefined;
+  const environments = nodes.map((env) => ({ ...env, targeted: env.id === targetedId }));
+
+  if (isJsonMode()) {
+    outputJson({
+      environments: environments.map((env) => ({
+        id: env.id,
+        name: env.name ?? null,
+        sandbox: env.sandbox ?? false,
+        project: env.projectName ?? null,
+        targeted: env.targeted,
+      })),
+    });
+    return;
+  }
+
+  if (environments.length === 0) {
+    console.log('No environments found.');
+    return;
+  }
+
+  const rows = environments.map((env) => [
+    env.targeted ? '▸' : '',
+    env.name ?? '—',
+    env.id,
+    env.projectName ?? '—',
+    env.sandbox ? 'Sandbox' : 'Production',
+  ]);
+  console.log(formatTable([{ header: '' }, { header: 'Name' }, { header: 'ID' }, { header: 'Project' }, { header: 'Type' }], rows));
+
+  const profileName = getConfig()?.activeEnvironment;
+  if (targetedId && profileName) {
+    console.log(chalk.dim(`\n  ▸ targeted by the active profile (${profileName})`));
+  }
+}
+
+export async function runEnvironmentUse(environmentIdArg?: string): Promise<void> {
+  const config = getConfig();
+  const activeName = config?.activeEnvironment;
+  if (!activeName) {
+    exitWithError({
+      code: 'no_active_environment',
+      message: `No active environment profile. Run \`${formatWorkOSCommand('auth login')}\` or \`${formatWorkOSCommand('profile add')}\` first.`,
+    });
+  }
+
+  const token = await requireCommandToken();
+  let environments: TeamEnvironment[];
+  try {
+    environments = await fetchTeamEnvironments(token);
+  } catch (error) {
+    reportDashboardError(error);
+  }
+  healProfiles(config, environments);
+
+  let targetId: string;
+  if (environmentIdArg) {
+    // Validate like the resolver does: an unrecognized ID stored on the
+    // profile would hit the server's silent production fallback on next use.
+    if (!environments.some((env) => env.id === environmentIdArg)) {
+      exitWithError({
+        code: 'not_found',
+        message: `Environment "${environmentIdArg}" was not found in your WorkOS team. Run \`${formatWorkOSCommand('environment list')}\` to see available environments.`,
+      });
+    }
+    targetId = environmentIdArg;
+  } else {
+    if (!isPromptAllowed()) {
+      exitWithError({
+        code: 'missing_args',
+        message: `Environment ID required when prompting is unavailable. Run \`${formatWorkOSCommand('environment list')}\` to see available IDs.`,
+      });
+    }
+    const choice = await promptForEnvironment(environments);
+    if (choice === null) exitWithCode(ExitCode.CANCELLED);
+    targetId = choice;
+  }
+
+  const chosen = environments.find((env) => env.id === targetId);
+  setProfileEnvironmentId(activeName, chosen!.id, chosen!.name);
+
+  outputSuccess(`Active profile ${chalk.bold(activeName)} now targets ${chalk.bold(chosen!.name ?? chosen!.id)}`, {
+    profile: activeName,
+    environmentId: chosen!.id,
+    environmentName: chosen!.name ?? null,
+  });
 }
 
 export interface EnvironmentCreateOptions {

--- a/src/commands/feature-flag.ts
+++ b/src/commands/feature-flag.ts
@@ -117,7 +117,7 @@ async function resolveProjectId(token: string, environmentId: string): Promise<s
       code: 'environment_stale',
       message:
         `Environment "${environmentId}" was not found in your WorkOS team — it may have been deleted or recreated. ` +
-        `Pass --environment-id, or run \`${formatWorkOSCommand('env switch')}\` to select an environment.`,
+        `Pass --environment-id, or run \`${formatWorkOSCommand('profile switch')}\` to select an environment.`,
     });
   }
   return project.id;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -251,7 +251,7 @@ export async function runLogin(): Promise<void> {
           }
         } else {
           ui.log.warn(
-            `Logged in as ${account.email ?? account.userId}, but the active environment "${provision.priorEnvName}" belongs to a different account (${priorLabel}). Keeping it active. Run \`${formatWorkOSCommand('env switch')}\` to change environments.`,
+            `Logged in as ${account.email ?? account.userId}, but the active environment "${provision.priorEnvName}" belongs to a different account (${priorLabel}). Keeping it active. Run \`${formatWorkOSCommand('profile switch')}\` to change environments.`,
           );
         }
       }
@@ -259,10 +259,10 @@ export async function runLogin(): Promise<void> {
       if (active) {
         ui.log.success(`Now using: ${active.name} (${active.type}) — ${account.email ?? account.userId}`);
       } else {
-        ui.log.info(chalk.dim(`Run \`${formatWorkOSCommand('env add')}\` to configure an environment manually`));
+        ui.log.info(chalk.dim(`Run \`${formatWorkOSCommand('profile add')}\` to configure an environment manually`));
       }
     } else {
-      ui.log.info(chalk.dim(`Run \`${formatWorkOSCommand('env add')}\` to configure an environment manually`));
+      ui.log.info(chalk.dim(`Run \`${formatWorkOSCommand('profile add')}\` to configure an environment manually`));
     }
 
     await maybeRunSetupAfter('login');

--- a/src/commands/vault-run.spec.ts
+++ b/src/commands/vault-run.spec.ts
@@ -382,7 +382,7 @@ describe('vault-run', () => {
         await expect(runVaultRun({ secrets: ['DB_URL=db'], command: ['echo'], env: 'no-such-env' })).rejects.toThrow(
           /__EXIT__/,
         );
-        expect(exitErrors[0].message).toContain('workos env list');
+        expect(exitErrors[0].message).toContain('workos profile list');
       });
     });
   });

--- a/src/commands/vault-run.ts
+++ b/src/commands/vault-run.ts
@@ -98,7 +98,7 @@ async function resolveRunApiKey(envName: string | undefined, flagApiKey?: string
   if (!env || !env.apiKey) {
     exitWithError({
       code: 'env_not_found',
-      message: `Environment '${envName}' not found or has no API key. Run '${formatWorkOSCommand('env list')}' to see available environments.`,
+      message: `Environment '${envName}' not found or has no API key. Run '${formatWorkOSCommand('profile list')}' to see available environments.`,
     });
   }
   return env.apiKey;

--- a/src/commands/verify-login.ts
+++ b/src/commands/verify-login.ts
@@ -138,7 +138,7 @@ export async function runVerifyLogin(options: VerifyLoginOptions): Promise<void>
       code: 'missing_client_id',
       message:
         `No client ID for the active environment. Pass --client-id, or configure one via ` +
-        `\`${formatWorkOSCommand('env add --client-id <id>')}\`.`,
+        `\`${formatWorkOSCommand('profile add --client-id <id>')}\`.`,
     });
   }
 

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -23,7 +23,7 @@ export function resolveApiKey(options?: ApiKeyOptions): string {
 
   exitWithError({
     code: 'no_api_key',
-    message: `No API key configured. Run \`${formatWorkOSCommand('env add')}\` to configure an environment, or set WORKOS_API_KEY.`,
+    message: `No API key configured. Run \`${formatWorkOSCommand('profile add')}\` to configure an environment, or set WORKOS_API_KEY.`,
   });
 }
 

--- a/src/lib/command-aliases.ts
+++ b/src/lib/command-aliases.ts
@@ -7,5 +7,7 @@
  */
 export const COMMAND_ALIASES: Record<string, string> = {
   org: 'organization',
-  claim: 'env.claim',
+  // `env` was the pre-0.22 name for local profiles; kept as a quiet alias.
+  env: 'profile',
+  claim: 'profile.claim',
 };

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -24,6 +24,13 @@ interface BaseEnvironmentConfig {
    * never silently falls back to the team's production environment.
    */
   environmentId?: string;
+  /**
+   * The dashboard environment's display name, captured at resolution time.
+   * Cosmetic only — `environmentId` is the identity — but it lets local
+   * commands show the same name the dashboard does without a network call.
+   * Refreshed by the same resolution paths that maintain `environmentId`.
+   */
+  environmentName?: string;
 }
 
 export interface ClaimedEnvironmentConfig extends BaseEnvironmentConfig {
@@ -101,11 +108,18 @@ export function setActiveEnvironment(name: string): void {
  * and opportunistic healing). No-op when the profile does not exist or already
  * stores the same ID — healing must never churn the keyring with no-op writes.
  */
-export function setProfileEnvironmentId(envKey: string, environmentId: string): void {
+export function setProfileEnvironmentId(
+  envKey: string,
+  environmentId: string,
+  environmentName?: string | null,
+): void {
   const config = getConfig();
   const profile = config?.environments[envKey];
-  if (!config || !profile || profile.environmentId === environmentId) return;
+  if (!config || !profile) return;
+  const nameUnchanged = environmentName === undefined || profile.environmentName === (environmentName ?? undefined);
+  if (profile.environmentId === environmentId && nameUnchanged) return;
   profile.environmentId = environmentId;
+  if (environmentName !== undefined) profile.environmentName = environmentName ?? undefined;
   saveConfig(config);
 }
 
@@ -185,6 +199,7 @@ export function markEnvironmentClaimed(): void {
       ...(env.ownerEmail && { ownerEmail: env.ownerEmail }),
       ...(env.ownerUserId && { ownerUserId: env.ownerUserId }),
       ...(env.environmentId && { environmentId: env.environmentId }),
+      ...(env.environmentName && { environmentName: env.environmentName }),
     };
 
     if (oldKey !== newKey) {

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -108,11 +108,7 @@ export function setActiveEnvironment(name: string): void {
  * and opportunistic healing). No-op when the profile does not exist or already
  * stores the same ID — healing must never churn the keyring with no-op writes.
  */
-export function setProfileEnvironmentId(
-  envKey: string,
-  environmentId: string,
-  environmentName?: string | null,
-): void {
+export function setProfileEnvironmentId(envKey: string, environmentId: string, environmentName?: string | null): void {
   const config = getConfig();
   const profile = config?.environments[envKey];
   if (!config || !profile) return;

--- a/src/lib/environment-target.spec.ts
+++ b/src/lib/environment-target.spec.ts
@@ -181,7 +181,7 @@ describe('resolveEnvironmentTarget', () => {
       await expect(resolveEnvironmentTarget('tok', { forMutation: true })).rejects.toThrow(CliExit);
       const err = errorSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
       expect(err).toContain('--environment-id');
-      expect(err).toContain('env switch');
+      expect(err).toContain('profile switch');
       expect(err).not.toMatch(/graphql/i);
     });
 
@@ -264,7 +264,7 @@ describe('resolveEnvironmentTarget', () => {
       expect(ui.select).not.toHaveBeenCalled();
       const err = errorSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
       expect(err).toContain('--environment-id');
-      expect(err).toContain('env switch');
+      expect(err).toContain('profile switch');
       expect(err).not.toMatch(/graphql/i);
     });
   });

--- a/src/lib/environment-target.ts
+++ b/src/lib/environment-target.ts
@@ -21,8 +21,8 @@
  * environments before the operation runs. The server silently falls back to
  * production for an unknown header, so trusting a stale ID is unsafe even for
  * reads: it can return real production data instead of an error. Whenever the
- * team's environments are fetched, the active profile is opportunistically
- * healed via its clientId join.
+ * team's environments are fetched, stored profiles are opportunistically
+ * healed via their clientId joins.
  */
 
 import ui from '../utils/ui.js';
@@ -47,7 +47,7 @@ export interface EnvironmentTarget {
   source: 'flag' | 'profile' | 'picker';
 }
 
-interface TeamEnvironment {
+export interface TeamEnvironment {
   id: string;
   name: string | null;
   sandbox?: boolean | null;
@@ -62,7 +62,7 @@ interface TeamProjectsData {
 
 /** The two remedies every unresolved/stale message must name. */
 function remedies(): string {
-  return `Pass --environment-id, or run \`${formatWorkOSCommand('env switch')}\` to select an environment.`;
+  return `Pass --environment-id, or run \`${formatWorkOSCommand('profile switch')}\` to select an environment.`;
 }
 
 /**
@@ -71,7 +71,7 @@ function remedies(): string {
  * whether that is fatal (`resolveEnvironmentTarget`) or best-effort
  * (`tryResolveProfileEnvironmentId`).
  */
-async function fetchTeamEnvironments(token: string): Promise<TeamEnvironment[]> {
+export async function fetchTeamEnvironments(token: string): Promise<TeamEnvironment[]> {
   const op = getOperation('teamProjectsV2');
   const data = await dashboardGraphqlRequest<TeamProjectsData>(resolveExecutableDocument(op), { token });
   const projects = data.currentTeam?.projectsV2 ?? [];
@@ -80,23 +80,25 @@ async function fetchTeamEnvironments(token: string): Promise<TeamEnvironment[]> 
 
 /**
  * Opportunistic healing: whenever the team's environments are fetched anyway,
- * re-join the active profile's clientId and persist the environment ID if it
- * changed (e.g. the environment was recreated). Profiles without a clientId
- * are never touched. Note: a picker choice persisted onto a clientId-bearing
- * profile (the foreign-profile fall-through, where the join missed) could be
- * overridden here if that clientId later appears in the team's list — the
- * join is then the fresher truth for this team, so that override is desired.
+ * re-join every clientId-bearing profile and persist the environment ID and
+ * name if they changed (e.g. the environment was recreated or renamed).
+ * Profiles without a clientId are never touched. Note: a picker choice
+ * persisted onto a clientId-bearing profile (the foreign-profile fall-through,
+ * where the join missed) could be overridden here if that clientId later
+ * appears in the team's list — the join is then the fresher truth for this
+ * team, so that override is desired.
  *
- * Takes the already-read config: every caller has one in hand, and the store
- * read is keyring IPC.
+ * Writes only happen on change (`setProfileEnvironmentId` no-ops otherwise),
+ * so a steady-state heal never churns the keyring. Takes the already-read
+ * config: every caller has one in hand, and the store read is keyring IPC.
  */
-function healActiveProfile(config: CliConfig | null, environments: TeamEnvironment[]): void {
-  if (!config?.activeEnvironment) return;
-  const profile = config.environments[config.activeEnvironment];
-  if (!profile?.clientId) return;
-  const match = environments.find((env) => env.clientId === profile.clientId);
-  if (!match) return;
-  setProfileEnvironmentId(config.activeEnvironment, match.id);
+export function healProfiles(config: CliConfig | null, environments: TeamEnvironment[]): void {
+  if (!config) return;
+  for (const [key, profile] of Object.entries(config.environments)) {
+    if (!profile.clientId) continue;
+    const match = environments.find((env) => env.clientId === profile.clientId);
+    if (match) setProfileEnvironmentId(key, match.id, match.name);
+  }
 }
 
 function exitStale(environmentId: string): never {
@@ -108,7 +110,7 @@ function exitStale(environmentId: string): never {
   });
 }
 
-async function promptForEnvironment(environments: TeamEnvironment[]): Promise<string | null> {
+export async function promptForEnvironment(environments: TeamEnvironment[]): Promise<string | null> {
   const choice = await ui.select({
     message: 'Select the WorkOS environment to target',
     options: environments.map((env) => ({
@@ -163,12 +165,12 @@ export async function resolveEnvironmentTarget(
   }
 
   // One store read serves healing and the picker-persist branch below; only
-  // the post-heal profile re-read needs fresher state than this snapshot.
+  // the post-heal active-profile re-read needs fresher state than this snapshot.
   const config = getConfig();
 
   // Heal before validating: a stale stored ID whose profile clientId still
   // joins to a live environment is silently repaired instead of erroring.
-  healActiveProfile(config, environments);
+  healProfiles(config, environments);
 
   if (flagValue) {
     // An explicit-but-mistyped ID hitting the server's silent fallback on a
@@ -197,7 +199,8 @@ export async function resolveEnvironmentTarget(
     // Healing never changes which profile is active, so the earlier config
     // snapshot is still authoritative for the profile name.
     if (config?.activeEnvironment) {
-      setProfileEnvironmentId(config.activeEnvironment, choice);
+      const chosen = environments.find((env) => env.id === choice);
+      setProfileEnvironmentId(config.activeEnvironment, choice, chosen?.name);
     }
     return { environmentId: choice, source: 'picker' };
   }
@@ -242,7 +245,7 @@ export async function tryResolveProfileEnvironmentId(
     if (profile.clientId) {
       const match = environments.find((env) => env.clientId === profile.clientId);
       if (match) {
-        setProfileEnvironmentId(envKey, match.id);
+        setProfileEnvironmentId(envKey, match.id, match.name);
         return true;
       }
       // A clientId that joins nothing usually means a foreign profile (an API
@@ -253,7 +256,8 @@ export async function tryResolveProfileEnvironmentId(
     if (options.allowPicker && isPromptAllowed()) {
       const choice = await promptForEnvironment(environments);
       if (choice === null) return false; // cancel skips resolution, never aborts the caller
-      setProfileEnvironmentId(envKey, choice);
+      const chosen = environments.find((env) => env.id === choice);
+      setProfileEnvironmentId(envKey, choice, chosen?.name);
       return true;
     }
 

--- a/src/lib/unclaimed-env-provision.ts
+++ b/src/lib/unclaimed-env-provision.ts
@@ -84,7 +84,7 @@ export async function tryProvisionUnclaimedEnv(options: UnclaimedEnvProvisionOpt
     config.activeEnvironment = key;
     saveConfig(config);
 
-    // Verify config persisted — critical for `workos env claim` in a later process
+    // Verify config persisted — critical for `workos profile claim` in a later process
     const readBack = getActiveEnvironment();
     if (!readBack || readBack.type !== 'unclaimed') {
       logError('[unclaimed-env-provision] Config read-back failed after save — claim token may not persist');
@@ -95,7 +95,7 @@ export async function tryProvisionUnclaimedEnv(options: UnclaimedEnvProvisionOpt
     logInfo('[unclaimed-env-provision] Unclaimed environment provisioned and saved');
     renderStderrNotice(
       `${chalk.green('✓')} ${chalk.bold('Environment provisioned')} ${chalk.dim('— credentials saved to your project')}`,
-      `${chalk.dim('Run')} ${chalk.bold.cyan(formatWorkOSCommand('env claim'))} ${chalk.dim('to link it to your account.')}`,
+      `${chalk.dim('Run')} ${chalk.bold.cyan(formatWorkOSCommand('profile claim'))} ${chalk.dim('to link it to your account.')}`,
     );
 
     return true;

--- a/src/lib/unclaimed-warning.ts
+++ b/src/lib/unclaimed-warning.ts
@@ -64,7 +64,7 @@ export async function warnIfUnclaimed(): Promise<void> {
     if (!isJsonMode()) {
       renderStderrNotice(
         `${pill('WARN', 'warn')}  ${chalk.bold('Unclaimed environment')} ${chalk.dim('— not linked to your account')}`,
-        `${chalk.dim('Run')} ${chalk.bold.cyan(formatWorkOSCommand('env claim'))} ${chalk.dim('to save it — its credentials live only on this machine.')}`,
+        `${chalk.dim('Run')} ${chalk.bold.cyan(formatWorkOSCommand('profile claim'))} ${chalk.dim('to save it — its credentials live only on this machine.')}`,
       );
       // Claim the one-notice-per-run slot so the lower-priority MCP banner defers.
       markStartupNoticeShown();

--- a/src/lib/workos-management.spec.ts
+++ b/src/lib/workos-management.spec.ts
@@ -268,7 +268,7 @@ describe('workos-management', () => {
       const value = rowFor('Environment').value;
       expect(value).toContain('unclaimed');
       expect(value).toContain('unclaimed-2');
-      expect(value).toContain('env claim');
+      expect(value).toContain('profile claim');
     });
 
     it('names a claimed active environment', async () => {
@@ -278,7 +278,7 @@ describe('workos-management', () => {
 
       const value = rowFor('Environment').value;
       expect(value).toBe('your active environment (sandbox)');
-      expect(value).not.toContain('env claim');
+      expect(value).not.toContain('profile claim');
     });
 
     it('falls back to the supplied-key wording with no active environment', async () => {
@@ -299,7 +299,7 @@ describe('workos-management', () => {
       const value = rowFor('Environment').value;
       expect(value).toBe('the API key supplied to this run');
       expect(value).not.toContain('unclaimed-2');
-      expect(value).not.toContain('env claim');
+      expect(value).not.toContain('profile claim');
     });
 
     it('does not name a claimed stored environment whose key did not do the writes', async () => {

--- a/src/lib/workos-management.ts
+++ b/src/lib/workos-management.ts
@@ -158,7 +158,7 @@ function describeCredentialProvenance(apiKey: string): string {
   if (!activeEnv || activeEnv.apiKey !== apiKey) return SUPPLIED_KEY_PROVENANCE;
 
   if (isUnclaimedEnvironment(activeEnv)) {
-    return `a new unclaimed environment (${activeEnv.name}) — run \`${formatWorkOSCommand('env claim')}\` to keep it`;
+    return `a new unclaimed environment (${activeEnv.name}) — run \`${formatWorkOSCommand('profile claim')}\` to keep it`;
   }
 
   return `your active environment (${activeEnv.name})`;

--- a/src/utils/help-json.spec.ts
+++ b/src/utils/help-json.spec.ts
@@ -58,7 +58,7 @@ describe('help-json', () => {
           'skills',
           'doctor',
           'verify-login',
-          'env',
+          'profile',
           'organization',
           'user',
           'install',
@@ -99,8 +99,8 @@ describe('help-json', () => {
 
   describe('buildCommandTree() — subcommand subtrees', () => {
     it('returns env subtree with subcommands', () => {
-      const tree = buildCommandTree('env');
-      expect(tree.name).toBe('env');
+      const tree = buildCommandTree('profile');
+      expect(tree.name).toBe('profile');
       const subNames = tree.commands!.map((c) => c.name);
       expect(subNames).toEqual(expect.arrayContaining(['add', 'remove', 'switch', 'list', 'claim', 'provision']));
     });
@@ -144,13 +144,13 @@ describe('help-json', () => {
     });
 
     it('env remove description states it is local-only', () => {
-      const env = buildCommandTree('env');
+      const env = buildCommandTree('profile');
       const remove = env.commands!.find((c) => c.name === 'remove');
       expect(remove!.description).toMatch(/local/i);
     });
 
     it('env claim description states the action is permanent', () => {
-      const env = buildCommandTree('env');
+      const env = buildCommandTree('profile');
       const claim = env.commands!.find((c) => c.name === 'claim');
       expect(claim!.description).toMatch(/permanent/i);
     });
@@ -158,7 +158,7 @@ describe('help-json', () => {
 
   describe('positional schemas', () => {
     it('env add has optional positionals', () => {
-      const env = buildCommandTree('env');
+      const env = buildCommandTree('profile');
       const add = env.commands!.find((c) => c.name === 'add');
       expect(add).toBeDefined();
       expect(add!.positionals).toBeDefined();
@@ -168,7 +168,7 @@ describe('help-json', () => {
     });
 
     it('env remove has required positional', () => {
-      const env = buildCommandTree('env');
+      const env = buildCommandTree('profile');
       const remove = env.commands!.find((c) => c.name === 'remove');
       expect(remove!.positionals![0].required).toBe(true);
     });

--- a/src/utils/help-json.ts
+++ b/src/utils/help-json.ts
@@ -159,9 +159,25 @@ const commands: CommandSchema[] = [
   },
   {
     name: 'environment',
-    description: 'Manage WorkOS environments (create, rename) on the dashboard account plane',
+    description: 'Manage WorkOS environments (list, use, create, rename) on the dashboard account plane',
     options: [insecureStorageOpt],
     commands: [
+      {
+        name: 'list',
+        description: "List the current team's environments",
+      },
+      {
+        name: 'use',
+        description: 'Point the active environment profile at a team environment',
+        positionals: [
+          {
+            name: 'environmentId',
+            type: 'string',
+            description: 'Environment ID to target (see `environment list`); omit to pick interactively',
+            required: false,
+          },
+        ],
+      },
       {
         name: 'create',
         description: 'Create a sandbox or production environment',
@@ -767,8 +783,8 @@ const commands: CommandSchema[] = [
     ],
   },
   {
-    name: 'env',
-    description: 'Manage environment configurations (API keys, endpoints, active environment)',
+    name: 'profile',
+    description: 'Manage local environment profiles (API keys, endpoints, active profile)',
     options: [insecureStorageOpt],
     commands: [
       {


### PR DESCRIPTION
## Why

A Slack thread asked "how does the CLI know my active environment — and which staging, when our team has multiple?" Answering it surfaced a UX gap: local credential profiles and dashboard environments are different things, but the CLI blurred them. Profile names (`staging`, `staging-2`, …) never lined up with dashboard names, the team's environments weren't visible or selectable, and `env` vs `environment` gave no signal about which plane you were on. Three people hit this confusion in one afternoon.

## What

**Dashboard names on profiles.** Every environment-resolution path (login clientId join, picker, healing) now also stores the environment's display name, and healing covers all clientId-bearing profiles. `profile list` shows the dashboard name (falling back to the raw ID); JSON gains `environmentId`/`environmentName` per profile.

**`workos environment list`.** Flat view of the team's environments across projects (name, ID, project, type), marking the one the active profile targets. Backed by the same `teamProjectsV2` fetch the resolver already uses.

**`workos environment use [environmentId]`.** Rebinds the active profile to a chosen team environment — interactive picker in human mode, explicit ID for scripts/agents. IDs are validated against the live team list so a typo can't silently route to the server's production fallback later.

**`workos env` → `workos profile`.** The local-profile commands are canonically `profile` now; `env` remains a quiet alias (same pattern as `org`/`organization`). All hints, help text, README, and MIGRATION.md updated; telemetry aggregates under `profile`.

**Help on missing subcommand (clig.dev).** Bare `workos environment` (and every command group) now prints the failing command's help subtree to stdout, with only the error line on stderr. Previously it printed just "Please specify a subcommand" — and any help routed through `console.error` shipped entirely red, because Bun tints that sink. Machine mode is unchanged: one structured `invalid_usage` error, exit 1.

**Table alignment fix.** `profile list` pads by visible width, so the chalk-colored `(unclaimed)` row no longer skews every column after it.

## Verification

- 2705 tests passing, typecheck clean
- Exercised live against a real account: `environment list` shows all 19 team environments, `environment use` rebind + restore round-trip, name backfill via healing, alias `env list` still works with identical JSON

## Notes for review

- `environment list`/`use` have no catalog-manifest entries: the manifest is one command noun per operation and `teamProjectsV2` belongs to `project list` (same precedent as `whoami`)
- `env` alias has no deprecation nag — retiring it is a separate decision