### PR TITLE
fix(install): surface unclaimed environments honestly

### DIFF
--- a/src/lib/adapters/cli-adapter.spec.ts
+++ b/src/lib/adapters/cli-adapter.spec.ts
@@ -523,5 +523,132 @@ describe('CLIAdapter', () => {
       expect(calls).toContain('Using your active WorkOS environment');
       expect(calls.join('\n')).not.toContain('Using environment:');
     });
+
+    it('unclaimed copy also covers the cli-flags path, which is where provisioning lands', async () => {
+      // runWithCore backfills options.apiKey/clientId from the .env.local that
+      // provisioning just wrote, so a freshly provisioned environment
+      // short-circuits at checkingCliFlags and never reaches staging
+      // resolution. The copy has to exist on this path or it never fires.
+      mockGetActiveEnvironment.mockReturnValue({
+        name: 'unclaimed',
+        type: 'unclaimed',
+        apiKey: 'sk_test_x',
+        clientId: 'client_x',
+        claimToken: 'ct_x',
+        authkitDomain: 'witty-rest-53.authkit.app',
+      });
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('credentials:found', {
+        source: 'env',
+        credentials: { clientId: 'client_x', apiKey: 'sk_test_x' },
+      });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls).toContain('Using a new WorkOS environment created for this install (witty-rest-53.authkit.app)');
+      expect(calls.join('\n')).not.toContain('Found existing WorkOS credentials');
+    });
+
+    it('names .env.local for an env-file backfill into a claimed environment', async () => {
+      mockGetActiveEnvironment.mockReturnValue({
+        name: 'staging-3',
+        type: 'sandbox',
+        apiKey: 'sk_test_x',
+        clientId: 'client_x',
+      });
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('credentials:found', {
+        source: 'env',
+        credentials: { clientId: 'client_x', apiKey: 'sk_test_x' },
+      });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls).toContain('Found existing WorkOS credentials in .env.local');
+    });
+
+    it('never claims .env.local for credentials passed as flags', async () => {
+      mockGetActiveEnvironment.mockReturnValue(null);
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('credentials:found', {
+        source: 'cli',
+        credentials: { clientId: 'client_flag', apiKey: 'sk_test_flag' },
+      });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls.join('\n')).not.toContain('.env.local');
+    });
+
+    it('says the environment is new and names it by AuthKit domain when unclaimed', async () => {
+      // Provisioning returns no environmentId/environmentName, so the generic
+      // "Using your active WorkOS environment" made a just-created environment
+      // read as one the user already had — the friction that sent people to the
+      // dashboard to compare client IDs.
+      mockGetActiveEnvironment.mockReturnValue({
+        name: 'unclaimed',
+        type: 'unclaimed',
+        apiKey: 'sk_test_x',
+        clientId: 'client_x',
+        claimToken: 'ct_x',
+        authkitDomain: 'witty-rest-53.authkit.app',
+      });
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('staging:fetching', {});
+      emitter.emit('staging:success', { source: 'stored', credentials: { clientId: 'client_x', apiKey: 'sk_test_x' } });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls).toContain('Using a new WorkOS environment created for this install (witty-rest-53.authkit.app)');
+      expect(calls.join('\n')).not.toContain('Using your active WorkOS environment');
+    });
+
+    it('drops the domain suffix for an unclaimed env provisioned before authkitDomain was stored', async () => {
+      mockGetActiveEnvironment.mockReturnValue({
+        name: 'unclaimed',
+        type: 'unclaimed',
+        apiKey: 'sk_test_x',
+        clientId: 'client_x',
+        claimToken: 'ct_x',
+      });
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('staging:fetching', {});
+      emitter.emit('staging:success', { source: 'stored', credentials: { clientId: 'client_x', apiKey: 'sk_test_x' } });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls).toContain('Using a new WorkOS environment created for this install');
+    });
+
+    it('keeps the generic copy when an unclaimed profile did not supply the credentials', async () => {
+      // A leftover unclaimed profile can sit active while the install used the
+      // project's own keys — calling that environment "created for this install"
+      // would be a lie about which environment the app now targets.
+      mockGetActiveEnvironment.mockReturnValue({
+        name: 'unclaimed',
+        type: 'unclaimed',
+        apiKey: 'sk_test_x',
+        clientId: 'client_x',
+        claimToken: 'ct_x',
+        authkitDomain: 'witty-rest-53.authkit.app',
+      });
+      await adapter.start();
+      const ui = await import('../../utils/ui.js');
+
+      emitter.emit('staging:fetching', {});
+      emitter.emit('staging:success', {
+        source: 'stored',
+        credentials: { clientId: 'client_x', apiKey: 'sk_test_project' },
+      });
+
+      const calls = vi.mocked(ui.default.log.success).mock.calls.map((c) => String(c[0]));
+      expect(calls).toContain('Using your active WorkOS environment');
+      expect(calls.join('\n')).not.toContain('created for this install');
+    });
   });
 });

--- a/src/lib/adapters/cli-adapter.ts
+++ b/src/lib/adapters/cli-adapter.ts
@@ -4,7 +4,7 @@ import { relative } from 'node:path';
 import ui, { PromptUnavailableError } from '../../utils/ui.js';
 import chalk from 'chalk';
 import { getConfig } from '../settings.js';
-import { getActiveEnvironment, profileEnvironmentLabel } from '../config-store.js';
+import { getActiveEnvironment, isUnclaimedEnvironment, profileEnvironmentLabel } from '../config-store.js';
 import { ProgressTracker } from '../progress-tracker.js';
 import { renderCompletionSummary, renderBrandMark } from '../../utils/summary-box.js';
 import { classifyAgentFailure, describeAgentFailure } from '../failure-classifier.js';
@@ -291,7 +291,39 @@ export class CLIAdapter implements InstallerAdapter {
     this.queueableLog(() => ui.log.warn('Could not detect framework automatically'));
   };
 
-  private handleCredentialsFound = (): void => {
+  /**
+   * Copy for an install running against a newly provisioned unclaimed
+   * environment, or undefined when it isn't.
+   *
+   * Provisioning returns no environmentId/environmentName, so
+   * `profileEnvironmentLabel` has nothing to build from and the generic copy
+   * reads as though the CLI picked up an environment the user already had —
+   * the ambiguity that sends people to the dashboard to compare client IDs.
+   *
+   * Requires an exact credential match: a leftover unclaimed profile can sit
+   * active while the install used the project's own keys, and calling that
+   * environment "created for this install" would misname what the app targets.
+   */
+  private newUnclaimedEnvironmentLine(credentials?: { clientId?: string; apiKey?: string }): string | undefined {
+    const active = getActiveEnvironment();
+    if (!active || !isUnclaimedEnvironment(active)) return undefined;
+    if (!credentials?.clientId || !credentials.apiKey) return undefined;
+    if (active.clientId !== credentials.clientId || active.apiKey !== credentials.apiKey) return undefined;
+    const domain = active.authkitDomain ? ` (${active.authkitDomain})` : '';
+    return `Using a new WorkOS environment created for this install${domain}`;
+  }
+
+  private handleCredentialsFound = ({ source, credentials }: InstallerEvents['credentials:found']): void => {
+    const newEnvironment = this.newUnclaimedEnvironmentLine(credentials);
+    if (newEnvironment) {
+      ui.log.success(newEnvironment);
+      return;
+    }
+    // Only the env-file backfill can honestly name .env.local. For credentials
+    // the user passed as flags, the integration installer announces them
+    // itself — naming a file they may never have touched is the same
+    // wrong-provenance claim in the other direction.
+    if (source === 'cli') return;
     ui.log.success('Found existing WorkOS credentials in .env.local');
   };
 
@@ -350,6 +382,18 @@ export class CLIAdapter implements InstallerAdapter {
     );
     const label = active && suppliedCredentials ? profileEnvironmentLabel(active) : undefined;
     const named = label ? `${label} (${active!.name})` : undefined;
+
+    // An unclaimed environment can never satisfy the naming above, so it gets
+    // its own copy (see newUnclaimedEnvironmentLine). Reachable here when
+    // .env.local was not pre-populated and checkStoredAuth routed an already
+    // active unclaimed profile through staging resolution.
+    const newEnvironment = this.newUnclaimedEnvironmentLine(credentials);
+    if (newEnvironment) {
+      this.stopSpinner('Environment ready');
+      ui.log.success(newEnvironment);
+      return;
+    }
+
     if (source === 'device') {
       this.stopSpinner('Environment ready');
       ui.log.success(named ? `Set up environment: ${named}` : 'Set up a WorkOS environment for this install');

--- a/src/lib/completion-data.spec.ts
+++ b/src/lib/completion-data.spec.ts
@@ -111,4 +111,49 @@ describe('buildCompletionData', () => {
     expect(data.signInSnippet).toBeUndefined();
     expect(data.nextSteps.some((s) => /refreshAuth/.test(s))).toBe(false);
   });
+
+  describe('unclaimed-environment claim step', () => {
+    it('leads the next steps with the claim command when one is supplied', async () => {
+      writePackageJson({ scripts: { dev: 'next dev' }, dependencies: { next: '15.0.0' } });
+
+      const data = await buildCompletionData(
+        { integration: 'nextjs', changedFiles: [], installDir },
+        { ...baseDeps, claimCommand: 'workos profile claim' },
+      );
+
+      // First, not buried: the provision-time notice has already scrolled away
+      // behind scaffolding and the agent run by the time this box renders.
+      expect(data.nextSteps[0]).toBe('Run `workos profile claim` to link this environment to your WorkOS account');
+      // The concrete steps still follow, in order.
+      expect(data.nextSteps[1]).toContain('start your dev server');
+      expect(data.nextSteps[2]).toContain('test authentication');
+    });
+
+    it('omits the claim step for a claimed environment', async () => {
+      writePackageJson({ scripts: { dev: 'next dev' }, dependencies: { next: '15.0.0' } });
+
+      const data = await buildCompletionData({ integration: 'nextjs', changedFiles: [], installDir }, baseDeps);
+
+      expect(data.nextSteps.some((s) => /claim/i.test(s))).toBe(false);
+      expect(data.nextSteps[0]).toContain('start your dev server');
+    });
+
+    it('keeps the claim step ahead of framework steps too', async () => {
+      writePackageJson({ scripts: { dev: 'next dev' }, dependencies: { next: '15.0.0' } });
+
+      const data = await buildCompletionData(
+        { integration: 'nextjs', changedFiles: [], installDir },
+        {
+          ...baseDeps,
+          claimCommand: 'workos profile claim',
+          frameworkNextSteps: ['Visit the WorkOS Dashboard to manage users and settings'],
+        },
+      );
+
+      const claimIndex = data.nextSteps.findIndex((s) => /profile claim/.test(s));
+      const dashboardIndex = data.nextSteps.findIndex((s) => /WorkOS Dashboard/.test(s));
+      expect(claimIndex).toBe(0);
+      expect(dashboardIndex).toBeGreaterThan(claimIndex);
+    });
+  });
 });

--- a/src/lib/completion-data.ts
+++ b/src/lib/completion-data.ts
@@ -24,6 +24,12 @@ export interface CompletionDataDeps {
   frameworkNextSteps?: string[];
   /** Per-framework "add a sign-in link" snippet */
   signInSnippet?: string;
+  /**
+   * Claim command for an unclaimed environment this install actually used
+   * (e.g. `workos profile claim`), or undefined for a claimed environment.
+   * Resolved by the caller, which owns the config lookup.
+   */
+  claimCommand?: string;
 }
 
 /**
@@ -49,12 +55,20 @@ export async function buildCompletionData(ctx: CompletionContext, deps: Completi
   // above already names the exact lockfile-aware command.
   const framework = (deps.frameworkNextSteps ?? []).filter((s) => !/start .*dev(elopment)? server/i.test(s));
 
+  // An unclaimed environment's credentials live only on this machine, so a
+  // missed claim loses the environment for good — it leads the next steps for
+  // that reason, and because the provision-time notice is printed before
+  // scaffolding and the agent run, minutes of output before the install ends.
+  const claim = deps.claimCommand
+    ? [`Run \`${deps.claimCommand}\` to link this environment to your WorkOS account`]
+    : [];
+
   return {
     integration: ctx.integration,
     devCommand,
     url,
     files,
-    nextSteps: [...concrete, ...framework],
+    nextSteps: [...claim, ...concrete, ...framework],
     docsUrl: deps.docsUrl,
     dashboardUrl: deps.dashboardUrl,
     signInSnippet: deps.signInSnippet,

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -37,6 +37,15 @@ interface BaseEnvironmentConfig {
    * disambiguate (e.g. "My Project > Staging").
    */
   projectName?: string;
+  /**
+   * The environment's AuthKit domain (e.g. `witty-rest-53.authkit.app`).
+   *
+   * The only human-recognizable identifier an unclaimed environment has:
+   * provisioning returns no `environmentId` or `environmentName`, so display
+   * paths that rely on `profileEnvironmentLabel` have nothing to print for a
+   * freshly provisioned environment. Cosmetic — never an identity key.
+   */
+  authkitDomain?: string;
 }
 
 export interface ClaimedEnvironmentConfig extends BaseEnvironmentConfig {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -57,7 +57,14 @@ export interface InstallerEvents {
   'git:dirty:confirmed': Record<string, never>;
   'git:dirty:cancelled': Record<string, never>;
   'credentials:gathering': { requiresApiKey: boolean };
-  'credentials:found': Record<string, never>;
+  /**
+   * Credentials were already on `options` when the machine started. `source`
+   * separates the two ways that happens — flags the user typed ('cli') versus a
+   * pair `runWithCore` backfilled from the project's env file ('env') — because
+   * the two need different copy, and the payload lets a listener check whether
+   * the active profile is the one that supplied them.
+   */
+  'credentials:found': { source?: 'cli' | 'env'; credentials?: { clientId?: string; apiKey?: string } };
   // Credential discovery events
   'credentials:env:detected': { files: string[] };
   'credentials:env:prompt': { files: string[] };

--- a/src/lib/installer-core.spec.ts
+++ b/src/lib/installer-core.spec.ts
@@ -414,6 +414,73 @@ describe('InstallerCore State Machine', () => {
       actor.stop();
     });
 
+    it('keeps an env-file provenance through the cli-flags short-circuit', async () => {
+      // runWithCore backfills options.apiKey/clientId from the project's
+      // .env.local — the path a freshly provisioned unclaimed environment takes.
+      // Those credentials must not be relabeled 'cli', or the installer tells
+      // the user it is using credentials they never provided.
+      const emitter = createInstallerEventEmitter();
+      const options: InstallerOptions = {
+        debug: false,
+        forceInstall: false,
+        installDir: '/test/project',
+        default: false,
+        local: true,
+        ci: false,
+        skipAuth: true,
+        dashboard: false,
+        emitter,
+        apiKey: 'sk_test_provisioned',
+        clientId: 'client_provisioned',
+        credentialSource: 'env',
+      };
+
+      const found: Array<{ source?: string }> = [];
+      emitter.on('credentials:found', (payload) => found.push(payload));
+
+      const actor = createActor(installerMachine.provide({ actors: baseMockActors }), {
+        input: { emitter, options },
+      });
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(found).toHaveLength(1);
+      expect(found[0].source).toBe('env');
+      actor.stop();
+    });
+
+    it('labels credentials that really came from flags as cli', async () => {
+      const emitter = createInstallerEventEmitter();
+      const options: InstallerOptions = {
+        debug: false,
+        forceInstall: false,
+        installDir: '/test/project',
+        default: false,
+        local: true,
+        ci: false,
+        skipAuth: true,
+        dashboard: false,
+        emitter,
+        apiKey: 'sk_test_flag',
+        clientId: 'client_flag',
+      };
+
+      const found: Array<{ source?: string }> = [];
+      emitter.on('credentials:found', (payload) => found.push(payload));
+
+      const actor = createActor(installerMachine.provide({ actors: baseMockActors }), {
+        input: { emitter, options },
+      });
+      actor.start();
+      actor.send({ type: 'START' });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(found).toHaveLength(1);
+      expect(found[0].source).toBe('cli');
+      actor.stop();
+    });
+
     it('skips device auth when checkStoredAuth returns true (unclaimed env)', async () => {
       const emitter = createInstallerEventEmitter();
       const options: InstallerOptions = {

--- a/src/lib/installer-core.ts
+++ b/src/lib/installer-core.ts
@@ -133,7 +133,10 @@ export const installerMachine = setup({
       context.emitter.emit('credentials:request', { requiresApiKey });
     },
     emitCredentialsFound: ({ context }) => {
-      context.emitter.emit('credentials:found', {});
+      context.emitter.emit('credentials:found', {
+        source: context.options.credentialSource === 'env' ? 'env' : 'cli',
+        credentials: { clientId: context.options.clientId, apiKey: context.options.apiKey },
+      });
     },
     emitEnvDetected: ({ context }) => {
       context.emitter.emit('credentials:env:detected', { files: context.envFilesDetected ?? [] });
@@ -751,7 +754,14 @@ export const installerMachine = setup({
               target: '#installer.configuring',
               guard: 'hasCredentials',
               actions: [
-                assign({ credentialSource: () => 'cli' as CredentialSource }),
+                // 'cli' means the user handed us these credentials. Credentials
+                // that only reached `options` because runWithCore backfilled them
+                // from the project's env file are not that, and calling them 'cli'
+                // is what made a freshly provisioned unclaimed environment
+                // announce itself as "the WorkOS credentials you provided".
+                assign({
+                  credentialSource: ({ context }) => context.options.credentialSource ?? ('cli' as CredentialSource),
+                }),
                 'emitCredentialsFound',
                 { type: 'emitStateExit', params: { state: 'gatheringCredentials' } },
               ],

--- a/src/lib/run-with-core.spec.ts
+++ b/src/lib/run-with-core.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { detectSingleIntegration } from './run-with-core.js';
+import { detectSingleIntegration, resolveCredentialSource } from './run-with-core.js';
 
 describe('detectSingleIntegration', () => {
   let dir: string;
@@ -73,5 +73,43 @@ describe('detectSingleIntegration', () => {
 
     const result = await detectSingleIntegration('kotlin', { installDir: dir });
     expect(result).toBe(true);
+  });
+});
+
+describe('resolveCredentialSource', () => {
+  it("labels a fully backfilled pair 'env'", () => {
+    // The provisioned unclaimed environment path: provisioning wrote the env
+    // file before the machine started, so the user supplied neither value.
+    const source = resolveCredentialSource(
+      { credentialSource: 'cli' },
+      { apiKey: 'sk_test_provisioned', clientId: 'client_provisioned' },
+    );
+
+    expect(source).toBe('env');
+  });
+
+  it('keeps the caller source when the user supplied both credentials', () => {
+    const source = resolveCredentialSource(
+      { apiKey: 'sk_test_flag', clientId: 'client_flag', credentialSource: 'cli' },
+      { apiKey: 'sk_test_file', clientId: 'client_file' },
+    );
+
+    expect(source).toBe('cli');
+  });
+
+  // Regression guard: a mixed pair used to be labeled 'env' wholesale, which
+  // made the installer announce `.env.local` as the origin of a credential the
+  // user had typed on the command line.
+  it('does not claim env provenance when only one credential was backfilled', () => {
+    expect(
+      resolveCredentialSource({ apiKey: 'sk_test_flag', credentialSource: 'cli' }, { clientId: 'client_file' }),
+    ).toBe('cli');
+    expect(
+      resolveCredentialSource({ clientId: 'client_flag', credentialSource: 'cli' }, { apiKey: 'sk_test_file' }),
+    ).toBe('cli');
+  });
+
+  it('leaves an unset caller source unset when there is nothing to backfill', () => {
+    expect(resolveCredentialSource({}, {})).toBeUndefined();
   });
 });

--- a/src/lib/run-with-core.ts
+++ b/src/lib/run-with-core.ts
@@ -14,6 +14,7 @@ import { getInteractionMode, isAgentMode, isCiMode } from '../utils/interaction-
 import { getOutputMode, isJsonMode, resolveEffectiveOutputMode, setOutputMode } from '../utils/output.js';
 import type {
   InstallerMachineContext,
+  CredentialSource,
   DetectionOutput,
   GitCheckOutput,
   AgentOutput,
@@ -23,6 +24,7 @@ import type {
 import { isScaffoldableEmptyDir, resolvePackageManager, runCreateNextApp } from './scaffold/index.js';
 import type { Integration } from './constants.js';
 import { readProjectEnvCredentials } from './project-env.js';
+import type { ProjectEnvCredentials } from './project-env.js';
 import { enableDebugLogs, initLogFile, logInfo, logError } from '../utils/debug.js';
 
 import { getAccessToken, saveCredentials } from './credentials.js';
@@ -152,6 +154,28 @@ export async function detectSingleIntegration(
   return false;
 }
 
+/**
+ * Provenance label for the credential pair `runWithCore` hands the machine.
+ *
+ * Only a pair the user supplied nothing toward can honestly name the project's
+ * env file as its origin. That total backfill is the path a freshly provisioned
+ * unclaimed environment takes — provisioning writes .env.local before the
+ * machine starts — and labeling it 'cli' is what made the installer claim
+ * credentials the user had never provided.
+ *
+ * A mixed pair keeps the caller's source instead: one flag plus one backfill is
+ * not an env-file resolution, and calling it one makes the installer announce
+ * `.env.local` as the origin of a value the user typed on the command line.
+ */
+export function resolveCredentialSource(
+  options: Pick<InstallerOptions, 'apiKey' | 'clientId' | 'credentialSource'>,
+  existingCreds: ProjectEnvCredentials,
+): CredentialSource | undefined {
+  const userSuppliedEither = Boolean(options.apiKey || options.clientId);
+  const backfilledFromProjectEnv = !userSuppliedEither && Boolean(existingCreds.apiKey || existingCreds.clientId);
+  return backfilledFromProjectEnv ? 'env' : options.credentialSource;
+}
+
 export async function runWithCore(options: InstallerOptions): Promise<void> {
   // Initialize debug/logging early so we capture all failures
   initLogFile();
@@ -172,18 +196,11 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
   analytics.setGatewayUrl(gatewayUrl);
 
   const existingCreds = readProjectEnvCredentials(options.installDir);
-  // Either credential arriving from the project's env file rather than from the
-  // user makes this an 'env' resolution, not 'cli'. This backfill is the path a
-  // freshly provisioned unclaimed environment takes — provisioning writes
-  // .env.local before the machine starts — so mislabeling it as 'cli' is what
-  // made the installer claim credentials the user had never provided.
-  const backfilledFromProjectEnv =
-    (!options.apiKey && Boolean(existingCreds.apiKey)) || (!options.clientId && Boolean(existingCreds.clientId));
   const augmentedOptions: InstallerOptions = {
     ...options,
     apiKey: options.apiKey || existingCreds.apiKey,
     clientId: options.clientId || existingCreds.clientId,
-    credentialSource: backfilledFromProjectEnv ? 'env' : options.credentialSource,
+    credentialSource: resolveCredentialSource(options, existingCreds),
   };
 
   const emitter = createInstallerEventEmitter();

--- a/src/lib/run-with-core.ts
+++ b/src/lib/run-with-core.ts
@@ -172,10 +172,18 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
   analytics.setGatewayUrl(gatewayUrl);
 
   const existingCreds = readProjectEnvCredentials(options.installDir);
+  // Either credential arriving from the project's env file rather than from the
+  // user makes this an 'env' resolution, not 'cli'. This backfill is the path a
+  // freshly provisioned unclaimed environment takes — provisioning writes
+  // .env.local before the machine starts — so mislabeling it as 'cli' is what
+  // made the installer claim credentials the user had never provided.
+  const backfilledFromProjectEnv =
+    (!options.apiKey && Boolean(existingCreds.apiKey)) || (!options.clientId && Boolean(existingCreds.clientId));
   const augmentedOptions: InstallerOptions = {
     ...options,
     apiKey: options.apiKey || existingCreds.apiKey,
     clientId: options.clientId || existingCreds.clientId,
+    credentialSource: backfilledFromProjectEnv ? 'env' : options.credentialSource,
   };
 
   const emitter = createInstallerEventEmitter();
@@ -346,13 +354,28 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
 
       buildCompletion: fromPromise<CompletionData | undefined, { context: InstallerMachineContext }>(
         async ({ input }) => {
-          const { integration, changedFiles, options: installerOptions } = input.context;
+          const { integration, changedFiles, options: installerOptions, credentials } = input.context;
           if (!integration) return undefined;
           try {
             const registry = await getRegistry();
             const mod = registry.get(integration);
             const cfg = mod?.config;
             const settings = getInstallerSettings();
+            // Read the config now, at the end of the install, not from a value
+            // captured earlier: the environment can be claimed mid-install (the
+            // browser claim CTA), and a claimed environment must not be told to
+            // claim itself. Exact credential match is required — a leftover
+            // unclaimed profile can sit active while this install used the
+            // project's own keys, and pointing that user at `claim` would name
+            // an environment their app never touched.
+            const activeEnv = getActiveEnvironment();
+            const usedUnclaimedEnv = Boolean(
+              activeEnv &&
+              isUnclaimedEnvironment(activeEnv) &&
+              credentials &&
+              activeEnv.apiKey === credentials.apiKey &&
+              activeEnv.clientId === credentials.clientId,
+            );
             return await buildCompletionData(
               { integration, changedFiles, installDir: installerOptions.installDir },
               {
@@ -362,6 +385,7 @@ export async function runWithCore(options: InstallerOptions): Promise<void> {
                 dashboardUrl: settings.documentation.dashboardUrl,
                 frameworkNextSteps: cfg?.ui.getOutroNextSteps?.({}) ?? [],
                 signInSnippet: cfg?.ui.getSignInSnippet?.({}),
+                claimCommand: usedUnclaimedEnv ? formatWorkOSCommand('profile claim') : undefined,
               },
             );
           } catch {

--- a/src/lib/unclaimed-env-provision.spec.ts
+++ b/src/lib/unclaimed-env-provision.spec.ts
@@ -105,10 +105,25 @@ describe('unclaimed-env-provision', () => {
             apiKey: 'sk_test_oneshot',
             clientId: 'client_01ABC',
             claimToken: 'ct_token123',
+            authkitDomain: 'auth.example.com',
           },
         },
         activeEnvironment: 'unclaimed',
       });
+    });
+
+    it('persists the AuthKit domain — the only printable name an unclaimed env has', async () => {
+      // Provisioning returns no environmentId/environmentName, so dropping this
+      // leaves profileEnvironmentLabel with nothing and every status line falls
+      // back to "your active WorkOS environment".
+      mockProvisionUnclaimedEnvironment.mockResolvedValueOnce(validProvisionResult);
+
+      await tryProvisionUnclaimedEnv({ installDir: testDir });
+
+      const saved = mockSaveConfig.mock.calls[0]?.[0] as {
+        environments: Record<string, { authkitDomain?: string }>;
+      };
+      expect(saved.environments.unclaimed.authkitDomain).toBe('auth.example.com');
     });
 
     it('preserves existing config environments', async () => {

--- a/src/lib/unclaimed-env-provision.ts
+++ b/src/lib/unclaimed-env-provision.ts
@@ -80,6 +80,11 @@ export async function tryProvisionUnclaimedEnv(options: UnclaimedEnvProvisionOpt
       apiKey: result.apiKey,
       clientId: result.clientId,
       claimToken: result.claimToken,
+      // Provisioning returns no environmentId/environmentName, so without this
+      // the environment has no printable name and every status line degrades to
+      // "your active WorkOS environment" — the ambiguity that sends people to
+      // the dashboard to check whether the CLI reused their existing env.
+      authkitDomain: result.authkitDomain,
     };
     config.activeEnvironment = key;
     saveConfig(config);


### PR DESCRIPTION
## Summary

Three coupled fixes to the zero-auth install path, all from the same finding: the installer minted an environment, then described it in a way that sent the tester to the dashboard to reconcile a client ID that didn't match anything they had.

- **Stop claiming credentials the user never provided.** The `credentialSource` gate from #200 was correct, but the label feeding it was not. `runWithCore` backfills `options.apiKey`/`clientId` from the project's `.env.local` before the state machine starts — and that is exactly the path a freshly provisioned unclaimed environment takes, since provisioning writes that file from `bin.ts` first. So `checkingCliFlags` short-circuited and hardcoded `'cli'`, and the installer announced _"Using the WorkOS credentials you provided"_ for credentials it had just minted itself. Credentials backfilled from a project env file are now labeled `'env'`.
- **Put the claim CTA where it will be read.** `workos profile claim` was printed once, at provision time, then buried under scaffolding and the whole agent run. It now leads the completion box's next steps — first, because an unclaimed environment's credentials live only on the local machine, so a missed claim is the one step that cannot be recovered later. Resolved by reading config _at completion_ (an environment claimed mid-install via the browser CTA is not told to claim itself) and gated on an exact credential match, so a leftover unclaimed profile can't name an environment this install never touched.
- **Give unclaimed environments a name.** `POST /x/one-shot-environments` returns no `environmentId` or `environmentName`, so `profileEnvironmentLabel()` had nothing to build from and the environment naming shipped in #231/#232 could never reach an unclaimed environment — every status line degraded to _"Using your active WorkOS environment"_, reading as though the CLI had picked up an environment the user already had. The `authkitDomain` the API already returns was being discarded; it is now persisted and rendered: _"Using a new WorkOS environment created for this install (witty-rest-53.authkit.app)"_.
- **Drive that copy from `credentials:found`, not just `staging:success`.** Worth a reviewer's attention: the provisioned-unclaimed path never reaches staging resolution, so anything added only to the `staging:success` handler is dead code for the most common zero-auth install. Both paths are handled.
- **Drop one more wrong-provenance claim.** `Found existing WorkOS credentials in .env.local` no longer prints for credentials passed as `--api-key`/`--client-id`, which never came from that file.

## Notes for reviewers

- `credentials:found` gained a payload (`source`, `credentials`); it was previously `Record<string, never>`.
- 13 tests added, including the negative cases: an unclaimed profile that did _not_ supply the credentials, and provenance surviving the cli-flags short-circuit.
- Verified by unit tests and code trace — **not** by a live `workos install`, which would provision a real unclaimed environment and run the agent end to end.
- `src/generated/runtime-deps-manifest.ts` is untracked and not in `.gitignore`, unlike its two siblings on lines 25-26. Pre-existing and left alone here, but probably worth a follow-up.
